### PR TITLE
Add varlink IPC between mech and mechd

### DIFF
--- a/mech_posix/Cargo.lock
+++ b/mech_posix/Cargo.lock
@@ -4,12 +4,13 @@ version = 4
 
 [[package]]
 name = "accesskit"
-version = "0.21.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf203f9d3bd8f29f98833d1fbef628df18f759248a547e7e01cfbf63cda36a99"
+checksum = "5351dcebb14b579ccab05f288596b2ae097005be7ee50a7c3d4ca9d0d5a66f6a"
 dependencies = [
  "enumn",
  "serde",
+ "uuid",
 ]
 
 [[package]]
@@ -226,26 +227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
-name = "arboard"
-version = "3.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
-dependencies = [
- "clipboard-win",
- "image",
- "log",
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-foundation",
- "parking_lot",
- "percent-encoding",
- "windows-sys 0.60.2",
- "x11rb",
-]
-
-[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "async-tungstenite"
-version = "0.32.1"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc405d38be14342132609f06f02acaf825ddccfe76c4824a69281e0458ebd4"
+checksum = "8447f02eaa65412035e2d3eeaa3fc82bbb8d7137c84c5976b4af685136012ee9"
 dependencies = [
  "atomic-waker",
  "futures-core",
@@ -422,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.3"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84ce723ab67259cfeb9877c6a639ee9eb7a27b28123abd71db7f0d5d0cc9d86"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -432,38 +413,14 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.36.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a442ece363113bd4bd4c8b18977a7798dd4d3c3383f34fb61936960e8f4ad8"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
-]
-
-[[package]]
-name = "background_hang_monitor"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "background_hang_monitor_api",
- "backtrace",
- "base",
- "crossbeam-channel",
- "libc",
- "log",
- "rustc-hash 2.1.1",
- "serde_json",
-]
-
-[[package]]
-name = "background_hang_monitor_api"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "base",
- "serde",
 ]
 
 [[package]]
@@ -482,34 +439,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "base"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "crossbeam-channel",
- "ipc-channel",
- "libc",
- "log",
- "mach2",
- "malloc_size_of_derive",
- "parking_lot",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "servo_config",
- "servo_malloc_size_of",
- "time",
- "unicode-segmentation",
- "webrender_api",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
@@ -544,14 +483,14 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn",
 ]
@@ -585,9 +524,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -635,6 +574,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +613,12 @@ dependencies = [
  "regex-automata 0.4.13",
  "serde",
 ]
+
+[[package]]
+name = "buf-read-ext"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e2c71c44e5bbc64de4ecfac946e05f9bba5cc296ea7bab4d3eda242a3ffa73c"
 
 [[package]]
 name = "build-parallel"
@@ -741,54 +695,6 @@ checksum = "e97f73e95d668625c9b28a3072e6326773785a0cf807de9f3d632778438f3d38"
 dependencies = [
  "core_maths",
  "displaydoc",
-]
-
-[[package]]
-name = "canvas"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "base",
- "bytemuck",
- "canvas_traits",
- "compositing_traits",
- "crossbeam-channel",
- "euclid",
- "fonts",
- "kurbo 0.12.0",
- "log",
- "peniko",
- "pixels",
- "profile_traits",
- "rustc-hash 2.1.1",
- "servo-tracing",
- "servo_config",
- "stylo",
- "vello_cpu",
- "webrender_api",
-]
-
-[[package]]
-name = "canvas_traits"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "base",
- "crossbeam-channel",
- "euclid",
- "fonts_traits",
- "glow",
- "ipc-channel",
- "kurbo 0.12.0",
- "malloc_size_of_derive",
- "pixels",
- "serde",
- "servo_config",
- "servo_malloc_size_of",
- "strum",
- "stylo",
- "webrender_api",
- "webxr-api",
 ]
 
 [[package]]
@@ -960,21 +866,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
-name = "clipboard-win"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
-dependencies = [
- "error-code",
-]
-
-[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1018,77 +924,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "compositing"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "base",
- "bincode",
- "bitflags 2.10.0",
- "canvas_traits",
- "compositing_traits",
- "constellation_traits",
- "crossbeam-channel",
- "dpi",
- "embedder_traits",
- "euclid",
- "gleam",
- "image",
- "ipc-channel",
- "log",
- "media",
- "profile_traits",
- "rayon",
- "rustc-hash 2.1.1",
- "servo-tracing",
- "servo_allocator",
- "servo_config",
- "servo_geometry",
- "servo_malloc_size_of",
- "smallvec",
- "stylo_traits",
- "surfman",
- "timers",
- "webgl",
- "webrender",
- "webrender_api",
- "wr_malloc_size_of",
-]
-
-[[package]]
-name = "compositing_traits"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "base",
- "bincode",
- "bitflags 2.10.0",
- "crossbeam-channel",
- "dpi",
- "embedder_traits",
- "euclid",
- "gleam",
- "glow",
- "image",
- "ipc-channel",
- "log",
- "malloc_size_of_derive",
- "parking_lot",
- "profile_traits",
- "raw-window-handle",
- "rustc-hash 2.1.1",
- "serde",
- "servo_geometry",
- "servo_malloc_size_of",
- "smallvec",
- "strum",
- "stylo",
- "stylo_traits",
- "surfman",
- "webrender_api",
-]
-
-[[package]]
 name = "compression-codecs"
 version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,95 +950,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "constellation"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "background_hang_monitor",
- "background_hang_monitor_api",
- "backtrace",
- "base",
- "canvas",
- "canvas_traits",
- "compositing_traits",
- "constellation_traits",
- "content-security-policy",
- "crossbeam-channel",
- "devtools_traits",
- "embedder_traits",
- "euclid",
- "fonts",
- "gaol",
- "ipc-channel",
- "keyboard-types",
- "layout_api",
- "log",
- "media",
- "net",
- "net_traits",
- "parking_lot",
- "profile",
- "profile_traits",
- "rand 0.9.2",
- "rustc-hash 2.1.1",
- "script_traits",
- "serde",
- "servo-tracing",
- "servo_config",
- "servo_url",
- "storage_traits",
- "stylo",
- "stylo_traits",
- "webgpu",
- "webgpu_traits",
- "webrender",
- "webrender_api",
- "webxr-api",
-]
-
-[[package]]
-name = "constellation_traits"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "base",
- "canvas_traits",
- "compositing_traits",
- "content-security-policy",
- "devtools_traits",
- "embedder_traits",
- "encoding_rs",
- "euclid",
- "fonts_traits",
- "http 1.4.0",
- "hyper_serde",
- "ipc-channel",
- "log",
- "malloc_size_of_derive",
- "net_traits",
- "pixels",
- "profile_traits",
- "rustc-hash 2.1.1",
- "serde",
- "servo_config",
- "servo_malloc_size_of",
- "servo_url",
- "storage_traits",
- "strum",
- "stylo_traits",
- "uuid",
- "webgpu_traits",
- "webrender_api",
-]
-
-[[package]]
 name = "content-security-policy"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52efb49c92268e4dcb64ea15d6733630f91bda721ef093f2e83959ea4fa241c0"
+checksum = "d348c3856ad6a6b957d69dc8cf93e66fe9be5a7657fdd7028b1a56d2775e3fce"
 dependencies = [
  "base64 0.22.1",
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "once_cell",
  "percent-encoding",
  "regex",
@@ -1288,7 +1041,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -1510,15 +1263,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
-name = "deny_public_fields"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,50 +1314,6 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn",
-]
-
-[[package]]
-name = "devtools"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "atomic_refcell",
- "base",
- "base64 0.22.1",
- "chrono",
- "crossbeam-channel",
- "devtools_traits",
- "embedder_traits",
- "headers 0.4.1",
- "http 1.4.0",
- "log",
- "net",
- "net_traits",
- "rand 0.9.2",
- "rustc-hash 2.1.1",
- "serde",
- "serde_json",
- "servo_config",
- "servo_url",
- "uuid",
-]
-
-[[package]]
-name = "devtools_traits"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "base",
- "bitflags 2.10.0",
- "embedder_traits",
- "http 1.4.0",
- "log",
- "malloc_size_of_derive",
- "net_traits",
- "serde",
- "servo_malloc_size_of",
- "servo_url",
- "uuid",
 ]
 
 [[package]]
@@ -1673,7 +1373,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "objc2",
 ]
 
@@ -1704,25 +1404,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
-]
-
-[[package]]
-name = "dom_struct"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "domobject_derive"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1808,37 +1489,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "embedder_traits"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "accesskit",
- "base",
- "bitflags 2.10.0",
- "cookie 0.18.1",
- "crossbeam-channel",
- "euclid",
- "http 1.4.0",
- "hyper_serde",
- "image",
- "ipc-channel",
- "keyboard-types",
- "log",
- "malloc_size_of_derive",
- "pixels",
- "rustc-hash 2.1.1",
- "serde",
- "servo_geometry",
- "servo_malloc_size_of",
- "servo_url",
- "strum",
- "stylo",
- "stylo_traits",
- "url",
- "uuid",
- "webdriver",
- "webrender_api",
-]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encoding_c"
@@ -1939,12 +1599,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-code"
-version = "3.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
-
-[[package]]
 name = "etagere"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,26 +1651,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fax"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "fdeflate"
@@ -2156,83 +1790,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fonts"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "app_units",
- "base",
- "bitflags 2.10.0",
- "byteorder",
- "compositing_traits",
- "content-security-policy",
- "core-foundation 0.9.4",
- "core-graphics",
- "core-text",
- "dwrote",
- "euclid",
- "fonts_traits",
- "fontsan",
- "freetype-sys",
- "harfbuzz-sys",
- "itertools 0.14.0",
- "libc",
- "log",
- "malloc_size_of_derive",
- "memmap2",
- "net_traits",
- "num-traits",
- "parking_lot",
- "profile_traits",
- "read-fonts",
- "rustc-hash 2.1.1",
- "serde",
- "servo-tracing",
- "servo_allocator",
- "servo_arc",
- "servo_config",
- "servo_malloc_size_of",
- "servo_url",
- "skrifa",
- "smallvec",
- "stylo",
- "stylo_atoms",
- "unicode-properties",
- "unicode-script",
- "url",
- "webrender_api",
- "winapi",
- "xml",
- "yeslogic-fontconfig-sys",
-]
-
-[[package]]
-name = "fonts_traits"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "atomic_refcell",
- "base",
- "dwrote",
- "log",
- "malloc_size_of_derive",
- "memmap2",
- "num-derive",
- "num-traits",
- "parking_lot",
- "profile_traits",
- "read-fonts",
- "serde",
- "servo_malloc_size_of",
- "servo_url",
- "stylo",
- "webrender_api",
-]
-
-[[package]]
 name = "fontsan"
 version = "0.6.1"
-source = "git+https://github.com/servo/fontsan#ec58e75f566648a256a4fe7264ea6ffa2b83f201"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52fd401b496627c46f35318272508fcdcb77927868507ed2ad796408aa903923"
 dependencies = [
  "cc",
  "fontsan-woff2",
@@ -2244,7 +1805,8 @@ dependencies = [
 [[package]]
 name = "fontsan-woff2"
 version = "0.1.1"
-source = "git+https://github.com/servo/fontsan#ec58e75f566648a256a4fe7264ea6ffa2b83f201"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106ebe29445505f3860765d2597ddad20a3e90174d6e8539a10d58253b3e5c0f"
 dependencies = [
  "brotli-decompressor",
  "cc",
@@ -2320,16 +1882,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
 
 [[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
-
-[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,7 +1889,6 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -2361,32 +1912,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures-sink"
@@ -2406,16 +1935,11 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -2440,13 +1964,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "gethostname"
-version = "1.1.0"
+name = "getrandom"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "rustix",
- "windows-link 0.2.1",
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -2457,7 +1982,7 @@ checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -2468,8 +1993,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -2570,7 +2108,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "gpu-alloc-types",
 ]
 
@@ -2580,7 +2118,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2601,7 +2139,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -2612,7 +2150,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2816,9 +2354,9 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.36.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
  "markup5ever",
@@ -2995,20 +2533,6 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "hyper_serde"
-version = "0.13.2"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "cookie 0.18.1",
- "headers 0.4.1",
- "http 1.4.0",
- "hyper 1.8.1",
- "mime",
- "serde_bytes",
- "serde_core",
 ]
 
 [[package]]
@@ -3576,6 +3100,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1adcf7b613a268af025bc2a2532b4b9ee294e6051c5c0832d8bff20ac0232e68"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3620,7 +3150,6 @@ dependencies = [
  "ravif",
  "rayon",
  "rgb",
- "tiff",
  "zune-core 0.5.1",
  "zune-jpeg 0.5.11",
 ]
@@ -3661,6 +3190,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3696,19 +3227,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipc-channel"
-version = "0.20.2"
+name = "inventory"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93600b5616c2d075f8af8dbd23c1d69278c5d24e4913d220cbc60b14c95c180"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
- "bincode",
+ "rustversion",
+]
+
+[[package]]
+name = "ipc-channel"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a441490012d80e9aea75fb27503df8e87e9557dcfc6fe4244dde86bfc12e94e3"
+dependencies = [
  "crossbeam-channel",
- "fnv",
  "libc",
  "mio",
+ "postcard",
  "rand 0.9.2",
- "serde",
+ "rustc-hash 2.1.2",
+ "serde_core",
  "tempfile",
+ "thiserror 2.0.18",
  "uuid",
  "windows 0.61.3",
 ]
@@ -3816,16 +3357,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jstraceable_derive"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "proc-macro2",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3850,7 +3381,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fbe853b403ae61a04233030ae8a79d94975281ed9770a1f9e246732b534b28d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "serde",
  "unicode-segmentation",
 ]
@@ -3896,93 +3427,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "layout"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "accesskit",
- "app_units",
- "atomic_refcell",
- "base",
- "bitflags 2.10.0",
- "compositing_traits",
- "cssparser",
- "data-url",
- "embedder_traits",
- "euclid",
- "fonts",
- "fonts_traits",
- "html5ever",
- "icu_locid",
- "icu_segmenter 1.5.0",
- "itertools 0.14.0",
- "kurbo 0.12.0",
- "layout_api",
- "log",
- "malloc_size_of_derive",
- "net_traits",
- "parking_lot",
- "pixels",
- "profile_traits",
- "rayon",
- "rustc-hash 2.1.1",
- "script",
- "script_traits",
- "selectors",
- "servo-tracing",
- "servo_arc",
- "servo_config",
- "servo_geometry",
- "servo_malloc_size_of",
- "servo_url",
- "smallvec",
- "strum",
- "stylo",
- "stylo_atoms",
- "stylo_traits",
- "taffy",
- "unicode-bidi",
- "unicode-script",
- "url",
- "webrender_api",
- "xi-unicode",
-]
-
-[[package]]
-name = "layout_api"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "app_units",
- "atomic_refcell",
- "background_hang_monitor_api",
- "base",
- "bitflags 2.10.0",
- "compositing_traits",
- "embedder_traits",
- "euclid",
- "fonts",
- "fonts_traits",
- "html5ever",
- "libc",
- "malloc_size_of_derive",
- "net_traits",
- "parking_lot",
- "pixels",
- "profile_traits",
- "rustc-hash 2.1.1",
- "script_traits",
- "selectors",
- "serde",
- "servo_arc",
- "servo_malloc_size_of",
- "servo_url",
- "stylo",
- "stylo_traits",
- "webrender_api",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3990,6 +3434,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lebe"
@@ -4035,70 +3485,9 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "libc",
  "redox_syscall 0.7.0",
-]
-
-[[package]]
-name = "libservo"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "accesskit",
- "arboard",
- "background_hang_monitor",
- "base",
- "bitflags 2.10.0",
- "canvas_traits",
- "compositing",
- "compositing_traits",
- "constellation",
- "constellation_traits",
- "crossbeam-channel",
- "devtools",
- "devtools_traits",
- "dpi",
- "embedder_traits",
- "env_logger",
- "euclid",
- "fonts",
- "gaol",
- "image",
- "ipc-channel",
- "keyboard-types",
- "layout",
- "layout_api",
- "log",
- "media",
- "mozangle",
- "net",
- "net_traits",
- "parking_lot",
- "profile",
- "profile_traits",
- "rustc-hash 2.1.1",
- "script",
- "script_traits",
- "serde",
- "servo-media",
- "servo-media-dummy",
- "servo-tracing",
- "servo_allocator",
- "servo_config",
- "servo_geometry",
- "servo_url",
- "storage",
- "storage_traits",
- "stylo",
- "stylo_traits",
- "surfman",
- "url",
- "webgl",
- "webgpu",
- "webrender",
- "webrender_api",
- "webxr",
 ]
 
 [[package]]
@@ -4180,12 +3569,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
 name = "mach2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4213,9 +3596,9 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.36.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril",
@@ -4240,29 +3623,13 @@ dependencies = [
  "clap",
  "dpi",
  "libc",
- "libservo",
  "predicates",
  "rustls",
  "serde",
  "serde_json",
+ "servo",
  "tempfile",
  "url",
-]
-
-[[package]]
-name = "media"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "compositing_traits",
- "euclid",
- "ipc-channel",
- "log",
- "rustc-hash 2.1.1",
- "serde",
- "servo-media",
- "servo_config",
- "webrender_api",
 ]
 
 [[package]]
@@ -4273,9 +3640,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -4286,7 +3653,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "block",
  "core-graphics-types 0.2.0",
  "foreign-types",
@@ -4296,25 +3663,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "base",
- "compositing_traits",
- "malloc_size_of_derive",
- "profile_traits",
- "script_traits",
- "servo_config",
- "servo_malloc_size_of",
- "servo_url",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime-multipart-hyper1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc819448803ee517eb413276ca59613c2850a95c4fdcd87ec82c5a6ce6cdab1a"
+dependencies = [
+ "buf-read-ext",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "mime",
+ "tempfile",
+ "textnonce",
+]
 
 [[package]]
 name = "mime_guess"
@@ -4349,7 +3716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -4392,9 +3759,9 @@ dependencies = [
 
 [[package]]
 name = "mozangle"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f4fcc47005b28e642cc098f2048a236fd8c531fc7a11b8b8bf14fb1230f122"
+checksum = "298bc7f83d5cca3789e47779e92cda492b75f11e03995bf558475bd9df2f639b"
 dependencies = [
  "bindgen",
  "cc",
@@ -4403,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.14.8"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f3329b0f19f40511bd7266d68ffbedf6d3d59157451927ec8d58ea010f6cda"
+checksum = "226edc79aa3f990a61330d4011471910273f6ee6bbfd0dcb93b18f5a03505f6b"
 dependencies = [
  "bindgen",
  "cc",
@@ -4418,9 +3785,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.140.5-10"
+version = "0.140.8-2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7047586e1b71e6405d42e4dfcefdcea209fea39adf2f60122bf72f192e19fbd1"
+checksum = "4b50224a02c96e1e703f7d055377431333dfc5cd3a09ccf03f8a2c8a156c7af8"
 dependencies = [
  "bindgen",
  "cc",
@@ -4442,7 +3809,7 @@ checksum = "916cbc7cb27db60be930a4e2da243cf4bc39569195f22fd8ee419cd31d5b662c"
 dependencies = [
  "arrayvec",
  "bit-set",
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
@@ -4473,112 +3840,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
-]
-
-[[package]]
-name = "net"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "async-compression",
- "async-recursion",
- "async-tungstenite",
- "base",
- "base64 0.22.1",
- "bytes",
- "chrono",
- "compositing_traits",
- "content-security-policy",
- "cookie 0.18.1",
- "crossbeam-channel",
- "data-url",
- "devtools_traits",
- "embedder_traits",
- "fst",
- "futures",
- "futures-core",
- "futures-util",
- "generic-array",
- "headers 0.4.1",
- "http 1.4.0",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls",
- "hyper-util",
- "hyper_serde",
- "imsz",
- "ipc-channel",
- "itertools 0.14.0",
- "log",
- "malloc_size_of_derive",
- "mime",
- "mime_guess",
- "net_traits",
- "nom 8.0.0",
- "parking_lot",
- "pixels",
- "profile_traits",
- "quick_cache",
- "resvg",
- "rustc-hash 2.1.1",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "serde",
- "servo_arc",
- "servo_config",
- "servo_malloc_size_of",
- "servo_url",
- "sha2",
- "time",
- "tokio",
- "tokio-rustls",
- "tokio-stream",
- "tokio-util",
- "tower",
- "tungstenite",
- "url",
- "uuid",
- "webpki-roots",
- "webrender_api",
-]
-
-[[package]]
-name = "net_traits"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "base",
- "compositing_traits",
- "content-security-policy",
- "cookie 0.18.1",
- "crossbeam-channel",
- "data-url",
- "embedder_traits",
- "headers 0.4.1",
- "http 1.4.0",
- "hyper-util",
- "hyper_serde",
- "ipc-channel",
- "log",
- "malloc_size_of_derive",
- "mime",
- "num-traits",
- "parking_lot",
- "percent-encoding",
- "pixels",
- "profile_traits",
- "rand 0.9.2",
- "rustc-hash 2.1.1",
- "rustls-pki-types",
- "serde",
- "servo_arc",
- "servo_malloc_size_of",
- "servo_url",
- "tokio",
- "url",
- "uuid",
- "webrender_api",
 ]
 
 [[package]]
@@ -4764,9 +4025,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -4777,10 +4038,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
- "objc2-core-graphics",
  "objc2-foundation",
  "objc2-quartz-core",
 ]
@@ -4791,8 +4051,10 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -4802,11 +4064,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -4815,7 +4094,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "objc2-core-foundation",
  "objc2-core-graphics",
 ]
@@ -4832,7 +4111,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -4843,7 +4122,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "libc",
  "objc2",
  "objc2-core-foundation",
@@ -4855,7 +4134,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -4866,7 +4145,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -5040,7 +4319,8 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 [[package]]
 name = "peek-poke"
 version = "0.3.0"
-source = "git+https://github.com/servo/webrender?rev=6cafc606096db4715a6119a6e16391aed9af47a5#6cafc606096db4715a6119a6e16391aed9af47a5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef60922033e31835f6cf98b9b81b58368037b71d2a81928985cd9d0b3b3171fb"
 dependencies = [
  "euclid",
  "peek-poke-derive",
@@ -5049,7 +4329,8 @@ dependencies = [
 [[package]]
 name = "peek-poke-derive"
 version = "0.3.0"
-source = "git+https://github.com/servo/webrender?rev=6cafc606096db4715a6119a6e16391aed9af47a5#6cafc606096db4715a6119a6e16391aed9af47a5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271f78bae1e699b58c180a384a2e8d78ccbb60b853e15db92339725f3a2764d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5187,21 +4468,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pixels"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "base",
- "euclid",
- "image",
- "log",
- "malloc_size_of_derive",
- "serde",
- "servo_malloc_size_of",
- "webrender_api",
-]
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5259,7 +4525,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -5302,6 +4568,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -5373,6 +4651,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5388,42 +4676,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "profile"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "base",
- "libc",
- "log",
- "mach2",
- "profile_traits",
- "regex",
- "serde",
- "serde_json",
- "servo_allocator",
- "servo_config",
- "tikv-jemalloc-sys",
- "time",
-]
-
-[[package]]
-name = "profile_traits"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "base",
- "crossbeam-channel",
- "ipc-channel",
- "log",
- "malloc_size_of_derive",
- "serde",
- "servo_allocator",
- "servo_config",
- "servo_malloc_size_of",
- "time",
 ]
 
 [[package]]
@@ -5487,6 +4739,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5505,6 +4776,16 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -5529,6 +4810,15 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -5543,6 +4833,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -5643,7 +4942,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -5652,7 +4951,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -5750,7 +5049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beceb6f7bf81c73e73aeef6dd1356d9a1b2b4909e1f0fc3e59b034f9572d7b7f"
 dependencies = [
  "base64 0.22.1",
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "serde",
  "serde_derive",
  "unicode-ident",
@@ -5790,7 +5089,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -5812,9 +5111,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -5831,7 +5130,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -5925,7 +5224,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "bytemuck",
  "core_maths",
  "log",
@@ -5974,223 +5273,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "script"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "aes",
- "aes-gcm",
- "aes-kw",
- "app_units",
- "argon2",
- "arrayvec",
- "atomic_refcell",
- "aws-lc-rs",
- "background_hang_monitor_api",
- "backtrace",
- "base",
- "base64 0.22.1",
- "base64ct",
- "bincode",
- "bitflags 2.10.0",
- "brotli",
- "canvas_traits",
- "cbc",
- "chacha20poly1305",
- "chardetng",
- "chrono",
- "cipher",
- "compositing_traits",
- "constellation_traits",
- "content-security-policy",
- "cookie 0.18.1",
- "crossbeam-channel",
- "cssparser",
- "ctr",
- "data-url",
- "deny_public_fields",
- "der",
- "devtools_traits",
- "digest",
- "dom_struct",
- "domobject_derive",
- "ecdsa",
- "elliptic-curve",
- "embedder_traits",
- "encoding_rs",
- "euclid",
- "flate2",
- "fonts",
- "fonts_traits",
- "glow",
- "headers 0.4.1",
- "hkdf",
- "html5ever",
- "http 1.4.0",
- "hyper_serde",
- "image",
- "indexmap",
- "ipc-channel",
- "itertools 0.14.0",
- "jstraceable_derive",
- "keyboard-types",
- "kurbo 0.12.0",
- "layout_api",
- "libc",
- "log",
- "malloc_size_of_derive",
- "markup5ever",
- "media",
- "metrics",
- "mime",
- "mime_guess",
- "ml-dsa",
- "ml-kem",
- "mozangle",
- "mozjs",
- "net_traits",
- "nom-rfc8288",
- "num-bigint-dig",
- "num-traits",
- "num_cpus",
- "ocb3",
- "p256",
- "p384",
- "p521",
- "parking_lot",
- "percent-encoding",
- "phf",
- "pixels",
- "pkcs8",
- "profile_traits",
- "rand 0.9.2",
- "regex",
- "rsa",
- "rustc-hash 2.1.1",
- "script_bindings",
- "script_traits",
- "sec1",
- "selectors",
- "serde",
- "serde_json",
- "servo-media",
- "servo_arc",
- "servo_config",
- "servo_geometry",
- "servo_malloc_size_of",
- "servo_url",
- "sha1",
- "sha2",
- "sha3",
- "smallvec",
- "storage_traits",
- "strum",
- "stylo",
- "stylo_atoms",
- "stylo_dom",
- "stylo_malloc_size_of",
- "stylo_traits",
- "swapper",
- "tempfile",
- "tendril",
- "time",
- "timers",
- "unicode-bidi",
- "unicode-script",
- "unicode-segmentation",
- "url",
- "urlpattern",
- "utf-8",
- "uuid",
- "webdriver",
- "webgpu_traits",
- "webrender_api",
- "wgpu-core",
- "wgpu-types",
- "x25519-dalek",
- "xml5ever",
- "xpath",
-]
-
-[[package]]
-name = "script_bindings"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "base",
- "bitflags 2.10.0",
- "crossbeam-channel",
- "deny_public_fields",
- "dom_struct",
- "domobject_derive",
- "html5ever",
- "indexmap",
- "jstraceable_derive",
- "keyboard-types",
- "libc",
- "log",
- "malloc_size_of_derive",
- "mozjs",
- "num-traits",
- "parking_lot",
- "phf",
- "phf_codegen",
- "phf_shared",
- "regex",
- "serde_json",
- "servo_arc",
- "servo_config",
- "servo_malloc_size_of",
- "servo_url",
- "smallvec",
- "stylo",
- "stylo_atoms",
- "tendril",
- "xml5ever",
-]
-
-[[package]]
-name = "script_traits"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "accesskit",
- "background_hang_monitor_api",
- "base",
- "canvas_traits",
- "compositing_traits",
- "constellation_traits",
- "content-security-policy",
- "crossbeam-channel",
- "devtools_traits",
- "embedder_traits",
- "euclid",
- "fonts_traits",
- "keyboard-types",
- "log",
- "malloc_size_of_derive",
- "media",
- "net_traits",
- "pixels",
- "profile_traits",
- "rustc-hash 2.1.1",
- "serde",
- "servo_config",
- "servo_malloc_size_of",
- "servo_url",
- "storage_traits",
- "strum",
- "stylo_atoms",
- "stylo_traits",
- "webrender_api",
- "webxr-api",
-]
-
-[[package]]
 name = "sea-query"
-version = "1.0.0-rc.29"
+version = "1.0.0-rc.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93948054fb2d208555a96d03d2c887591deb42ffe3210eedbd8a3234c6fb6d34"
+checksum = "58decdaaaf2a698170af2fa1b2e8f7b43a970e7768bf18aebaab113bada46354"
 dependencies = [
  "inherent",
  "sea-query-derive",
@@ -6198,9 +5284,9 @@ dependencies = [
 
 [[package]]
 name = "sea-query-derive"
-version = "1.0.0-rc.11"
+version = "1.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365d236217f5daa4f40d3c9998ff3921351b53472da50308e384388162353b3a"
+checksum = "8d88ad44b6ad9788c8b9476b6b91f94c7461d1e19d39cd8ea37838b1e6ff5aa8"
 dependencies = [
  "darling",
  "heck 0.4.1",
@@ -6240,7 +5326,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -6259,10 +5345,11 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.35.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "cssparser",
  "derive_more",
  "log",
@@ -6270,7 +5357,7 @@ dependencies = [
  "phf",
  "phf_codegen",
  "precomputed-hash",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "servo_arc",
  "smallvec",
  "to_shmem",
@@ -6329,6 +5416,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -6349,9 +5437,652 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0070e405abc520d91ff75db643bca36f9d13e99b9b3448c6bcc154769d4a75fe"
+dependencies = [
+ "accesskit",
+ "bitflags 2.11.1",
+ "cookie 0.18.1",
+ "crossbeam-channel",
+ "dpi",
+ "env_logger",
+ "euclid",
+ "gaol",
+ "image",
+ "ipc-channel",
+ "keyboard-types",
+ "log",
+ "mozangle",
+ "parking_lot",
+ "rustc-hash 2.1.2",
+ "serde",
+ "servo-background-hang-monitor",
+ "servo-base",
+ "servo-canvas-traits",
+ "servo-config",
+ "servo-constellation",
+ "servo-constellation-traits",
+ "servo-default-resources",
+ "servo-devtools",
+ "servo-devtools-traits",
+ "servo-embedder-traits",
+ "servo-fonts",
+ "servo-geometry",
+ "servo-layout",
+ "servo-layout-api",
+ "servo-media",
+ "servo-media-dummy",
+ "servo-media-thread",
+ "servo-net",
+ "servo-net-traits",
+ "servo-paint",
+ "servo-paint-api",
+ "servo-profile",
+ "servo-profile-traits",
+ "servo-script",
+ "servo-script-traits",
+ "servo-storage",
+ "servo-storage-traits",
+ "servo-tracing",
+ "servo-url",
+ "servo-webgl",
+ "servo-webgpu",
+ "servo-webxr",
+ "stylo",
+ "stylo_traits",
+ "surfman",
+ "tokio",
+ "url",
+ "webrender",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-allocator"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d8013ec6b49e7fc3c93d82550ab944536dc843a1cfd3d32691f5030854871af"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+ "tikv-jemallocator",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "servo-background-hang-monitor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc008a0ae4a818390b09e67b0b113a17259666c8594372565186b8485a3dad13"
+dependencies = [
+ "backtrace",
+ "crossbeam-channel",
+ "libc",
+ "log",
+ "rustc-hash 2.1.2",
+ "serde_json",
+ "servo-background-hang-monitor-api",
+ "servo-base",
+]
+
+[[package]]
+name = "servo-background-hang-monitor-api"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8e6392cea0a079d759adeae3f9f4afdfbd2736680545be2dcdce90d61dd813a"
+dependencies = [
+ "serde",
+ "servo-base",
+]
+
+[[package]]
+name = "servo-base"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "652c96d26c12eb1a80c1de5cd352eeae6d5450f4903f860484142138b26bb596"
+dependencies = [
+ "accesskit",
+ "crossbeam-channel",
+ "ipc-channel",
+ "libc",
+ "log",
+ "mach2",
+ "malloc_size_of_derive",
+ "parking_lot",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "servo-config",
+ "servo-malloc-size-of",
+ "time",
+ "unicode-segmentation",
+ "webrender_api",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "servo-canvas"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a860146427668731437efb0b2fa98e09d3a481a4d29b826eb2cdcdad4cd5704"
+dependencies = [
+ "bytemuck",
+ "crossbeam-channel",
+ "euclid",
+ "kurbo 0.12.0",
+ "log",
+ "peniko",
+ "rustc-hash 2.1.2",
+ "servo-base",
+ "servo-canvas-traits",
+ "servo-config",
+ "servo-fonts",
+ "servo-paint-api",
+ "servo-pixels",
+ "servo-profile-traits",
+ "servo-tracing",
+ "stylo",
+ "vello_cpu",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-canvas-traits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f18e3688716e4accaa2614a54bc17e71624b965a4132e66b6191218e77d75e7"
+dependencies = [
+ "crossbeam-channel",
+ "euclid",
+ "glow",
+ "kurbo 0.12.0",
+ "malloc_size_of_derive",
+ "serde",
+ "servo-base",
+ "servo-fonts-traits",
+ "servo-malloc-size-of",
+ "servo-pixels",
+ "servo-webxr-api",
+ "strum",
+ "stylo",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-config"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d453a08194c46a1ef557b82bfc5d101ef26de6a8101e6d79a7eb6773ed346056"
+dependencies = [
+ "serde",
+ "serde_json",
+ "servo-config-macro",
+ "stylo_static_prefs",
+]
+
+[[package]]
+name = "servo-config-macro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50eeff1d9312db321e09f7b9da39994656583507b12cbc21000d5de9d73ac8a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "servo-constellation"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c5a79abbad7c9d96bedf6f047e69f777993ffd820c80ac4c66154475800afe"
+dependencies = [
+ "accesskit",
+ "backtrace",
+ "content-security-policy",
+ "crossbeam-channel",
+ "euclid",
+ "gaol",
+ "ipc-channel",
+ "keyboard-types",
+ "log",
+ "parking_lot",
+ "rand 0.9.2",
+ "rustc-hash 2.1.2",
+ "serde",
+ "servo-background-hang-monitor",
+ "servo-background-hang-monitor-api",
+ "servo-base",
+ "servo-canvas",
+ "servo-canvas-traits",
+ "servo-config",
+ "servo-constellation-traits",
+ "servo-devtools-traits",
+ "servo-embedder-traits",
+ "servo-fonts",
+ "servo-layout-api",
+ "servo-media-thread",
+ "servo-net",
+ "servo-net-traits",
+ "servo-paint-api",
+ "servo-profile-traits",
+ "servo-script-traits",
+ "servo-storage-traits",
+ "servo-tracing",
+ "servo-url",
+ "servo-webgpu",
+ "servo-webgpu-traits",
+ "servo-webxr-api",
+ "stylo",
+ "stylo_traits",
+]
+
+[[package]]
+name = "servo-constellation-traits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9586a099986a4f42749f576cacd086054e031021cd91110dab5e0b8ef2e51ab"
+dependencies = [
+ "content-security-policy",
+ "encoding_rs",
+ "euclid",
+ "http 1.4.0",
+ "ipc-channel",
+ "log",
+ "malloc_size_of_derive",
+ "rustc-hash 2.1.2",
+ "serde",
+ "servo-base",
+ "servo-canvas-traits",
+ "servo-config",
+ "servo-devtools-traits",
+ "servo-embedder-traits",
+ "servo-fonts-traits",
+ "servo-hyper-serde",
+ "servo-malloc-size-of",
+ "servo-net-traits",
+ "servo-paint-api",
+ "servo-pixels",
+ "servo-profile-traits",
+ "servo-storage-traits",
+ "servo-url",
+ "servo-webgpu-traits",
+ "strum",
+ "uuid",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-default-resources"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4207da426d1d47862349e6743ffd8ac8c1488d9a8a5eed03a83ff9e163697da"
+dependencies = [
+ "servo-embedder-traits",
+]
+
+[[package]]
+name = "servo-deny-public-fields"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98fae4310bb51f47eb651f5e18085902ff0fb6202b81db4c30ff3ecdc2f9c0bc"
+dependencies = [
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "servo-devtools"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "868371dece681d1ca370e763bd5093a4c322eab7fa137969a405a65b9cb9fceb"
+dependencies = [
+ "atomic_refcell",
+ "base64 0.22.1",
+ "chrono",
+ "crossbeam-channel",
+ "headers 0.4.1",
+ "http 1.4.0",
+ "log",
+ "malloc_size_of_derive",
+ "rand 0.9.2",
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_json",
+ "servo-base",
+ "servo-config",
+ "servo-devtools-traits",
+ "servo-embedder-traits",
+ "servo-malloc-size-of",
+ "servo-net",
+ "servo-net-traits",
+ "servo-profile-traits",
+ "servo-url",
+ "uuid",
+]
+
+[[package]]
+name = "servo-devtools-traits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e44b3824b411e24d2155baf43fda4de8ae31ccf28b978402c769226a1b082a77"
+dependencies = [
+ "http 1.4.0",
+ "malloc_size_of_derive",
+ "serde",
+ "servo-base",
+ "servo-embedder-traits",
+ "servo-malloc-size-of",
+ "servo-net-traits",
+ "servo-profile-traits",
+ "servo-url",
+ "uuid",
+]
+
+[[package]]
+name = "servo-dom-struct"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f913de114000e33ebada6f4d82edc72575325894e043be9b1d0499e1ace75e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "servo-embedder-traits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5f5632ee546288b8d50c823b710afa56219aca202dd0d990fdc166c84120da"
+dependencies = [
+ "accesskit",
+ "bitflags 2.11.1",
+ "cookie 0.18.1",
+ "crossbeam-channel",
+ "euclid",
+ "http 1.4.0",
+ "image",
+ "inventory",
+ "keyboard-types",
+ "log",
+ "malloc_size_of_derive",
+ "rustc-hash 2.1.2",
+ "serde",
+ "servo-base",
+ "servo-geometry",
+ "servo-hyper-serde",
+ "servo-malloc-size-of",
+ "servo-pixels",
+ "servo-url",
+ "strum",
+ "stylo",
+ "stylo_traits",
+ "url",
+ "uuid",
+ "webdriver",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-fonts"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db31f28feaab1159deb1e31b96ac3e320d54dd3e1a8b373acf8f95059354d15c"
+dependencies = [
+ "app_units",
+ "bitflags 2.11.1",
+ "byteorder",
+ "content-security-policy",
+ "dwrote",
+ "euclid",
+ "fontsan",
+ "freetype-sys",
+ "harfbuzz-sys",
+ "icu_locid",
+ "icu_properties 1.5.1",
+ "itertools 0.14.0",
+ "libc",
+ "log",
+ "malloc_size_of_derive",
+ "memmap2",
+ "num-traits",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-text",
+ "parking_lot",
+ "read-fonts",
+ "rustc-hash 2.1.2",
+ "serde",
+ "servo-allocator",
+ "servo-base",
+ "servo-config",
+ "servo-fonts-traits",
+ "servo-malloc-size-of",
+ "servo-net-traits",
+ "servo-paint-api",
+ "servo-profile-traits",
+ "servo-tracing",
+ "servo-url",
+ "servo_arc",
+ "skrifa",
+ "smallvec",
+ "stylo",
+ "stylo_atoms",
+ "unicode-properties",
+ "unicode-script",
+ "url",
+ "uuid",
+ "webrender_api",
+ "winapi",
+ "xml",
+ "yeslogic-fontconfig-sys",
+]
+
+[[package]]
+name = "servo-fonts-traits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7119d37b59f0c02b48499ad916a80b901114a174d3bdc872b8e59be9cc7e3c6"
+dependencies = [
+ "atomic_refcell",
+ "dwrote",
+ "log",
+ "malloc_size_of_derive",
+ "memmap2",
+ "num-derive",
+ "num-traits",
+ "parking_lot",
+ "read-fonts",
+ "serde",
+ "servo-base",
+ "servo-malloc-size-of",
+ "servo-profile-traits",
+ "servo-url",
+ "stylo",
+ "uuid",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-geometry"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3bbac0f89e8f20941a26d6e68861f313fbb01e79b18b1c1bd56ca0179063676"
+dependencies = [
+ "app_units",
+ "euclid",
+ "malloc_size_of_derive",
+ "servo-malloc-size-of",
+ "webrender",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-hyper-serde"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72838514a505b8b8f056f8f4a9e7c2aea8bf2ed14b8573ffc28e5a54926a9447"
+dependencies = [
+ "cookie 0.18.1",
+ "headers 0.4.1",
+ "http 1.4.0",
+ "hyper 1.8.1",
+ "mime",
+ "serde_bytes",
+ "serde_core",
+]
+
+[[package]]
+name = "servo-jstraceable-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35253dd08315fd35726155b7470aad195ccdff476d92ac959992c067c0b9e3e4"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "servo-layout"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be71eb9497abe74c4e2daec8617bfa14e4378f293795231fd96597308ba27ac2"
+dependencies = [
+ "app_units",
+ "atomic_refcell",
+ "bitflags 2.11.1",
+ "data-url",
+ "euclid",
+ "html5ever",
+ "icu_locid",
+ "icu_segmenter 1.5.0",
+ "itertools 0.14.0",
+ "kurbo 0.12.0",
+ "log",
+ "malloc_size_of_derive",
+ "parking_lot",
+ "rayon",
+ "rustc-hash 2.1.2",
+ "selectors",
+ "servo-base",
+ "servo-config",
+ "servo-embedder-traits",
+ "servo-fonts",
+ "servo-fonts-traits",
+ "servo-geometry",
+ "servo-layout-api",
+ "servo-malloc-size-of",
+ "servo-net-traits",
+ "servo-paint-api",
+ "servo-pixels",
+ "servo-profile-traits",
+ "servo-script",
+ "servo-script-traits",
+ "servo-tracing",
+ "servo-url",
+ "servo_arc",
+ "smallvec",
+ "strum",
+ "stylo",
+ "stylo_atoms",
+ "stylo_traits",
+ "taffy",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode_categories",
+ "url",
+ "webrender_api",
+ "xi-unicode",
+]
+
+[[package]]
+name = "servo-layout-api"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b513bc3cc4d4efd5e1f689633095a4fc780642b3a9ba0082df1283ae395f84a2"
+dependencies = [
+ "app_units",
+ "atomic_refcell",
+ "bitflags 2.11.1",
+ "euclid",
+ "html5ever",
+ "libc",
+ "malloc_size_of_derive",
+ "parking_lot",
+ "rustc-hash 2.1.2",
+ "selectors",
+ "serde",
+ "servo-background-hang-monitor-api",
+ "servo-base",
+ "servo-embedder-traits",
+ "servo-fonts",
+ "servo-malloc-size-of",
+ "servo-net-traits",
+ "servo-paint-api",
+ "servo-pixels",
+ "servo-profile-traits",
+ "servo-script-traits",
+ "servo-url",
+ "servo_arc",
+ "stylo",
+ "stylo_traits",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-malloc-size-of"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "351361a0978e50fdc7e2198cb7e7a4c74c68f6f6b57915c3108a76036e07f153"
+dependencies = [
+ "accountable-refcell",
+ "app_units",
+ "atomic_refcell",
+ "content-security-policy",
+ "crossbeam-channel",
+ "encoding_rs",
+ "euclid",
+ "http 1.4.0",
+ "indexmap",
+ "ipc-channel",
+ "keyboard-types",
+ "markup5ever",
+ "mime",
+ "parking_lot",
+ "resvg",
+ "servo-allocator",
+ "servo_arc",
+ "smallvec",
+ "string_cache",
+ "stylo",
+ "stylo_dom",
+ "stylo_malloc_size_of",
+ "taffy",
+ "tendril",
+ "time",
+ "tokio",
+ "unicode-bidi",
+ "unicode-script",
+ "url",
+ "urlpattern",
+ "uuid",
+ "webrender",
+ "webrender_api",
+ "wr_malloc_size_of",
+]
+
+[[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b832794132cd7f36b4a5f8f8a1b0a7640160b1f9d2716fa7a16c2e36df0df1ef"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -6363,17 +6094,20 @@ dependencies = [
 
 [[package]]
 name = "servo-media-audio"
-version = "0.2.0"
-source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36a31cfa701b2b51dbf2b40c52bc15f785265553c211d4160292459953c56e99"
 dependencies = [
  "byte-slice-cast",
  "euclid",
  "log",
+ "malloc_size_of_derive",
  "num-complex",
  "num-traits",
  "petgraph",
  "serde",
  "serde_derive",
+ "servo-malloc-size-of",
  "servo-media-derive",
  "servo-media-player",
  "servo-media-streams",
@@ -6385,7 +6119,8 @@ dependencies = [
 [[package]]
 name = "servo-media-derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fdc309a170b22d23787925a26213d912eb8b48c2ec31abcaba27bfd665f190"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6395,7 +6130,8 @@ dependencies = [
 [[package]]
 name = "servo-media-dummy"
 version = "0.1.0"
-source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "933cc33fb330745d7fef9437b1bf6ef00377ce2ffdfce3dd407a1b47ce018da2"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -6409,11 +6145,14 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1d19c7b0c783382b457907085916187e8f35c1d9fb7a1adccfc3a644782237"
 dependencies = [
  "ipc-channel",
+ "malloc_size_of_derive",
  "serde",
  "serde_derive",
+ "servo-malloc-size-of",
  "servo-media-streams",
  "servo-media-traits",
 ]
@@ -6421,20 +6160,48 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "454b562e8309468c1afce9691ff59720c55c4ca7abe0c8c66385e7fe5a6f5ccd"
 dependencies = [
+ "malloc_size_of_derive",
+ "servo-malloc-size-of",
  "uuid",
+]
+
+[[package]]
+name = "servo-media-thread"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc8a15eefd0c1dfeb2feabe5ec449ce81df1fa5c1c12f95404fecbf38d090f9d"
+dependencies = [
+ "euclid",
+ "ipc-channel",
+ "log",
+ "malloc_size_of_derive",
+ "rustc-hash 2.1.2",
+ "serde",
+ "servo-config",
+ "servo-malloc-size-of",
+ "servo-media",
+ "servo-paint-api",
+ "webrender_api",
 ]
 
 [[package]]
 name = "servo-media-traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aa16dc86558337e9b997872cdd03262f0743fdcf25892bdd0bf572e2677ef6b"
+dependencies = [
+ "malloc_size_of_derive",
+ "servo-malloc-size-of",
+]
 
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81ef80f1b85d057b48f9473761a27f013094884a63d649ab6355d9b3f7f29e47"
 dependencies = [
  "log",
  "servo-media-streams",
@@ -6442,123 +6209,666 @@ dependencies = [
 ]
 
 [[package]]
-name = "servo-tracing"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
+name = "servo-metrics"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349524fd3a66a99e0027575bd246807d657213711d1f606bbc019c996aacc67a"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "servo_allocator"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
- "tikv-jemallocator",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "servo_arc"
-version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
-dependencies = [
- "serde",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "servo_config"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "serde",
- "serde_json",
- "servo_config_macro",
- "servo_url",
- "stylo_config",
-]
-
-[[package]]
-name = "servo_config_macro"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "servo_geometry"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "app_units",
- "euclid",
  "malloc_size_of_derive",
- "servo_malloc_size_of",
- "webrender",
+ "servo-base",
+ "servo-config",
+ "servo-malloc-size-of",
+ "servo-paint-api",
+ "servo-profile-traits",
+ "servo-script-traits",
+ "servo-url",
+]
+
+[[package]]
+name = "servo-net"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c577079bb3ef21a4fd7bb36f452aa63b25882e2a7726276cea47ea577d224721"
+dependencies = [
+ "async-compression",
+ "async-recursion",
+ "async-tungstenite",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "content-security-policy",
+ "cookie 0.18.1",
+ "crossbeam-channel",
+ "data-url",
+ "fst",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "generic-array",
+ "headers 0.4.1",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls",
+ "hyper-util",
+ "imsz",
+ "ipc-channel",
+ "itertools 0.14.0",
+ "log",
+ "malloc_size_of_derive",
+ "mime",
+ "mime_guess",
+ "nom 8.0.0",
+ "parking_lot",
+ "quick_cache",
+ "regex",
+ "resvg",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "servo-base",
+ "servo-config",
+ "servo-devtools-traits",
+ "servo-embedder-traits",
+ "servo-hyper-serde",
+ "servo-malloc-size-of",
+ "servo-net-traits",
+ "servo-paint-api",
+ "servo-pixels",
+ "servo-profile-traits",
+ "servo-url",
+ "servo_arc",
+ "sha2",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tungstenite",
+ "url",
+ "uuid",
+ "webpki-roots",
  "webrender_api",
 ]
 
 [[package]]
-name = "servo_malloc_size_of"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
+name = "servo-net-traits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9625ab5589003db438ba7a266f19d28dbfac09fe2b84cd08adb6c72d0625eab4"
 dependencies = [
- "accountable-refcell",
- "app_units",
- "atomic_refcell",
  "content-security-policy",
+ "cookie 0.18.1",
  "crossbeam-channel",
- "euclid",
+ "data-url",
+ "headers 0.4.1",
  "http 1.4.0",
- "indexmap",
+ "hyper-util",
  "ipc-channel",
- "keyboard-types",
- "markup5ever",
+ "log",
+ "malloc_size_of_derive",
  "mime",
+ "num-traits",
  "parking_lot",
- "resvg",
- "servo_allocator",
+ "percent-encoding",
+ "rand 0.9.2",
+ "rustc-hash 2.1.2",
+ "rustls-pki-types",
+ "serde",
+ "servo-base",
+ "servo-config",
+ "servo-embedder-traits",
+ "servo-hyper-serde",
+ "servo-malloc-size-of",
+ "servo-paint-api",
+ "servo-pixels",
+ "servo-profile-traits",
+ "servo-url",
  "servo_arc",
- "smallvec",
- "string_cache",
- "stylo",
- "stylo_dom",
- "stylo_malloc_size_of",
- "taffy",
- "tendril",
+ "sys-locale",
  "tokio",
- "unicode-bidi",
- "unicode-script",
  "url",
- "urlpattern",
- "utf-8",
  "uuid",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-paint"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0a4a54c85d0d196aa3e2a1802b2b3cfe9b599a05bc32004138a798af2842a3"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossbeam-channel",
+ "dpi",
+ "euclid",
+ "gleam",
+ "image",
+ "ipc-channel",
+ "log",
+ "rayon",
+ "rustc-hash 2.1.2",
+ "servo-allocator",
+ "servo-base",
+ "servo-canvas-traits",
+ "servo-config",
+ "servo-constellation-traits",
+ "servo-embedder-traits",
+ "servo-geometry",
+ "servo-malloc-size-of",
+ "servo-media-thread",
+ "servo-paint-api",
+ "servo-profile-traits",
+ "servo-timers",
+ "servo-tracing",
+ "servo-webgl",
+ "smallvec",
+ "stylo_traits",
+ "surfman",
  "webrender",
  "webrender_api",
  "wr_malloc_size_of",
 ]
 
 [[package]]
-name = "servo_url"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
+name = "servo-paint-api"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f579bc5f06a675ebebecee4b9dc3975010a0c06e68cae9cde805aff5800ca3"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossbeam-channel",
+ "dpi",
+ "euclid",
+ "gleam",
+ "glow",
+ "image",
+ "ipc-channel",
+ "log",
+ "malloc_size_of_derive",
+ "parking_lot",
+ "raw-window-handle",
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_bytes",
+ "servo-base",
+ "servo-embedder-traits",
+ "servo-geometry",
+ "servo-malloc-size-of",
+ "servo-profile-traits",
+ "servo-tracing",
+ "servo-url",
+ "smallvec",
+ "strum",
+ "stylo",
+ "stylo_traits",
+ "surfman",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-pixels"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1fa7656e3deae84546d147ea7eeb5373d6ba2fb20bd3ed1ff82a19427aad6b4"
+dependencies = [
+ "euclid",
+ "image",
+ "log",
+ "malloc_size_of_derive",
+ "serde",
+ "servo-base",
+ "servo-malloc-size-of",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-profile"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c977f737c66d814c5b6d121018e7541ddc861f4313a93a0b8acc14a2f7645202"
+dependencies = [
+ "libc",
+ "log",
+ "mach2",
+ "regex",
+ "serde",
+ "serde_json",
+ "servo-allocator",
+ "servo-base",
+ "servo-config",
+ "servo-profile-traits",
+ "tikv-jemalloc-sys",
+ "time",
+]
+
+[[package]]
+name = "servo-profile-traits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe4720dbdedadebe5b9c644305adfb8ec2293ce0ae65c832f3af83d58573377"
+dependencies = [
+ "crossbeam-channel",
+ "ipc-channel",
+ "log",
+ "malloc_size_of_derive",
+ "serde",
+ "servo-allocator",
+ "servo-base",
+ "servo-malloc-size-of",
+ "time",
+]
+
+[[package]]
+name = "servo-script"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea90266d3eaa76429e7d29f1dda49ad11e0b96fd0d887fb7b0cea1f01a0895d8"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "aes-kw",
+ "app_units",
+ "argon2",
+ "arrayvec",
+ "atomic_refcell",
+ "aws-lc-rs",
+ "backtrace",
+ "base64 0.22.1",
+ "base64ct",
+ "bitflags 2.11.1",
+ "brotli",
+ "cbc",
+ "chacha20poly1305",
+ "chardetng",
+ "chrono",
+ "cipher",
+ "content-security-policy",
+ "cookie 0.18.1",
+ "crossbeam-channel",
+ "cssparser",
+ "ctr",
+ "data-url",
+ "der",
+ "digest",
+ "ecdsa",
+ "elliptic-curve",
+ "encoding_rs",
+ "euclid",
+ "flate2",
+ "glow",
+ "headers 0.4.1",
+ "hkdf",
+ "html5ever",
+ "http 1.4.0",
+ "icu_locid",
+ "indexmap",
+ "ipc-channel",
+ "itertools 0.14.0",
+ "keyboard-types",
+ "libc",
+ "log",
+ "malloc_size_of_derive",
+ "markup5ever",
+ "mime",
+ "mime-multipart-hyper1",
+ "mime_guess",
+ "ml-dsa",
+ "ml-kem",
+ "mozangle",
+ "mozjs",
+ "nom-rfc8288",
+ "num-bigint-dig",
+ "num-traits",
+ "num_cpus",
+ "ocb3",
+ "p256",
+ "p384",
+ "p521",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pkcs8",
+ "postcard",
+ "rand 0.9.2",
+ "regex",
+ "rsa",
+ "rustc-hash 2.1.2",
+ "sec1",
+ "selectors",
+ "serde",
+ "serde_json",
+ "servo-background-hang-monitor-api",
+ "servo-base",
+ "servo-canvas-traits",
+ "servo-config",
+ "servo-constellation-traits",
+ "servo-deny-public-fields",
+ "servo-devtools-traits",
+ "servo-dom-struct",
+ "servo-embedder-traits",
+ "servo-fonts",
+ "servo-fonts-traits",
+ "servo-geometry",
+ "servo-hyper-serde",
+ "servo-jstraceable-derive",
+ "servo-layout-api",
+ "servo-malloc-size-of",
+ "servo-media",
+ "servo-media-thread",
+ "servo-metrics",
+ "servo-net-traits",
+ "servo-paint-api",
+ "servo-pixels",
+ "servo-profile-traits",
+ "servo-script-bindings",
+ "servo-script-traits",
+ "servo-storage-traits",
+ "servo-timers",
+ "servo-url",
+ "servo-webgpu-traits",
+ "servo-xpath",
+ "servo_arc",
+ "sha1",
+ "sha2",
+ "sha3",
+ "smallvec",
+ "strum",
+ "stylo",
+ "stylo_atoms",
+ "stylo_dom",
+ "stylo_malloc_size_of",
+ "stylo_traits",
+ "swapper",
+ "tempfile",
+ "tendril",
+ "time",
+ "unicode-bidi",
+ "unicode-script",
+ "url",
+ "urlpattern",
+ "uuid",
+ "webdriver",
+ "webrender_api",
+ "wgpu-core",
+ "wgpu-types",
+ "x25519-dalek",
+ "xml5ever",
+]
+
+[[package]]
+name = "servo-script-bindings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1237e5599ea3857a3cd76f0ec6cd6cfafd2acf274966f960ace001b87b2d891"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossbeam-channel",
+ "encoding_rs",
+ "html5ever",
+ "indexmap",
+ "keyboard-types",
+ "libc",
+ "log",
+ "malloc_size_of_derive",
+ "mozjs",
+ "num-traits",
+ "parking_lot",
+ "phf",
+ "phf_codegen",
+ "phf_shared",
+ "regex",
+ "serde_json",
+ "servo-base",
+ "servo-config",
+ "servo-deny-public-fields",
+ "servo-dom-struct",
+ "servo-jstraceable-derive",
+ "servo-malloc-size-of",
+ "servo-profile-traits",
+ "servo-url",
+ "servo_arc",
+ "smallvec",
+ "stylo",
+ "stylo_atoms",
+ "tendril",
+ "xml5ever",
+]
+
+[[package]]
+name = "servo-script-traits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc2d83cc0e14e0d3914881ae51b1eead81502afe06dbee4996df1f137fb6a6c"
+dependencies = [
+ "accesskit",
+ "crossbeam-channel",
+ "euclid",
+ "keyboard-types",
+ "malloc_size_of_derive",
+ "rustc-hash 2.1.2",
+ "serde",
+ "servo-base",
+ "servo-canvas-traits",
+ "servo-config",
+ "servo-constellation-traits",
+ "servo-devtools-traits",
+ "servo-embedder-traits",
+ "servo-fonts-traits",
+ "servo-malloc-size-of",
+ "servo-media-thread",
+ "servo-net-traits",
+ "servo-paint-api",
+ "servo-pixels",
+ "servo-profile-traits",
+ "servo-storage-traits",
+ "servo-url",
+ "servo-webxr-api",
+ "strum",
+ "stylo_atoms",
+ "stylo_traits",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-storage"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65ed9c35f2831bbafc3a846555daeb829e42a50c75cab753a0af691b1a92a324"
+dependencies = [
+ "libc",
+ "log",
+ "malloc_size_of_derive",
+ "postcard",
+ "rusqlite",
+ "rustc-hash 2.1.2",
+ "sea-query",
+ "sea-query-rusqlite",
+ "serde",
+ "servo-base",
+ "servo-config",
+ "servo-malloc-size-of",
+ "servo-net-traits",
+ "servo-profile-traits",
+ "servo-storage-traits",
+ "servo-url",
+ "tempfile",
+ "uuid",
+]
+
+[[package]]
+name = "servo-storage-traits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7c15d38ed849e268a2cf0f9adab96f80d1b2cbaf00e67b1787f035a6fde000"
+dependencies = [
+ "malloc_size_of_derive",
+ "serde",
+ "servo-base",
+ "servo-malloc-size-of",
+ "servo-profile-traits",
+ "servo-url",
+ "uuid",
+]
+
+[[package]]
+name = "servo-timers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc03b1dd9ac0e5c11ff2d3dce1a0879fd0f0e42c670723b2c475539c64197370"
+dependencies = [
+ "crossbeam-channel",
+ "malloc_size_of_derive",
+ "servo-malloc-size-of",
+]
+
+[[package]]
+name = "servo-tracing"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "404ade73d66d656d6d84c43d4c5e52a744b1be33c0adf44dc48d5c90535b1009"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "servo-url"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6704e3fcc79b00776e68fe896bc2429bf2f08dc665d3010a0e914b570993b8e"
 dependencies = [
  "encoding_rs",
  "malloc_size_of_derive",
  "serde",
+ "servo-malloc-size-of",
  "servo_arc",
- "servo_malloc_size_of",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "servo-webgl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6994dc5b85ac5d848ff58ad6ea74ce9a7444c1c46f1ef806aab76790ff60bb"
+dependencies = [
+ "bitflags 2.11.1",
+ "byteorder",
+ "crossbeam-channel",
+ "euclid",
+ "glow",
+ "half",
+ "itertools 0.14.0",
+ "log",
+ "parking_lot",
+ "rustc-hash 2.1.2",
+ "servo-base",
+ "servo-canvas-traits",
+ "servo-paint-api",
+ "servo-pixels",
+ "surfman",
+ "webrender_api",
+]
+
+[[package]]
+name = "servo-webgpu"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26fcecae88239ee15fa5a10351c2bc5d09d084f63abdab0bc70931d8fb1f7947"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "log",
+ "rustc-hash 2.1.2",
+ "servo-base",
+ "servo-config",
+ "servo-paint-api",
+ "servo-pixels",
+ "servo-webgpu-traits",
+ "webrender_api",
+ "wgpu-core",
+ "wgpu-types",
+]
+
+[[package]]
+name = "servo-webgpu-traits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5ed6c27d606ce6537cfec6d7a1a249d9c69a4603dc53aa770a72e77bda6ef8"
+dependencies = [
+ "arrayvec",
+ "malloc_size_of_derive",
+ "serde",
+ "servo-base",
+ "servo-malloc-size-of",
+ "servo-pixels",
+ "webrender_api",
+ "wgpu-core",
+ "wgpu-types",
+]
+
+[[package]]
+name = "servo-webxr"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efdbc5c1be1fdf250978506d303132719a502ec9b81462c7c42f76688187feb5"
+dependencies = [
+ "crossbeam-channel",
+ "euclid",
+ "glow",
+ "log",
+ "openxr",
+ "raw-window-handle",
+ "servo-base",
+ "servo-profile-traits",
+ "servo-webxr-api",
+ "surfman",
+ "winapi",
+ "wio",
+]
+
+[[package]]
+name = "servo-webxr-api"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a475bc39579c269a02d9f988709d691b295dbbd2887e178ea613b482cecb50"
+dependencies = [
+ "euclid",
+ "ipc-channel",
+ "log",
+ "malloc_size_of_derive",
+ "serde",
+ "servo-base",
+ "servo-embedder-traits",
+ "servo-malloc-size-of",
+ "servo-profile-traits",
+]
+
+[[package]]
+name = "servo-xpath"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e8bd73d8165bdbb46fcfce8af60fab54398ac47071e7402dea354b25ce079af"
+dependencies = [
+ "log",
+ "malloc_size_of_derive",
+ "markup5ever",
+ "servo-malloc-size-of",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -6723,7 +7033,7 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6747,50 +7057,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "storage"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "base",
- "bincode",
- "libc",
- "log",
- "malloc_size_of_derive",
- "net_traits",
- "profile_traits",
- "rusqlite",
- "rustc-hash 2.1.1",
- "sea-query",
- "sea-query-rusqlite",
- "serde",
- "serde_json",
- "servo_config",
- "servo_malloc_size_of",
- "servo_url",
- "storage_traits",
- "tempfile",
- "tokio",
- "tokio-rustls",
- "tokio-stream",
- "tokio-util",
- "uuid",
-]
-
-[[package]]
-name = "storage_traits"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "base",
- "malloc_size_of_derive",
- "profile_traits",
- "serde",
- "servo_malloc_size_of",
- "servo_url",
- "uuid",
-]
 
 [[package]]
 name = "strck"
@@ -6850,18 +7116,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -6871,13 +7137,14 @@ dependencies = [
 
 [[package]]
 name = "stylo"
-version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c032879feb9c437f8eb370b1ddc56c13531267766bd6f3ada99c406d36d60a6"
 dependencies = [
  "app_units",
  "arrayvec",
  "atomic_refcell",
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "byteorder",
  "cssparser",
  "derive_more",
@@ -6899,7 +7166,7 @@ dependencies = [
  "precomputed-hash",
  "rayon",
  "rayon-core",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "selectors",
  "serde",
  "servo_arc",
@@ -6907,8 +7174,9 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "string_cache",
+ "strum",
+ "strum_macros",
  "stylo_atoms",
- "stylo_config",
  "stylo_derive",
  "stylo_dom",
  "stylo_malloc_size_of",
@@ -6926,22 +7194,19 @@ dependencies = [
 
 [[package]]
 name = "stylo_atoms"
-version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb92d87ad2ba792800cc2bf508eb17286044303ebe55b15cd7e541190486c86"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
 ]
 
 [[package]]
-name = "stylo_config"
-version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
-
-[[package]]
 name = "stylo_derive"
-version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338d14b4375657058b395afcf11bee2fc22a77e9d80f66ee863b617b38d4319a"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -6952,17 +7217,19 @@ dependencies = [
 
 [[package]]
 name = "stylo_dom"
-version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa592a930bd67daa5c9c07bc7b422f23f67b5bd30532e85a6fcfef348cf0fb9"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "stylo_malloc_size_of",
 ]
 
 [[package]]
 name = "stylo_malloc_size_of"
-version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8cd4ec615ff7bbc849d1d7d95891c39db20dfd1cb79eb8ba29c54107a4101a3"
 dependencies = [
  "app_units",
  "cssparser",
@@ -6978,16 +7245,18 @@ dependencies = [
 
 [[package]]
 name = "stylo_static_prefs"
-version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc94d0d425d29db1da9535b12793a0db91e85ca2fde13adc73df33f49ee75af7"
 
 [[package]]
 name = "stylo_traits"
-version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cc7f5c9b43201f0d5c81ca190ccbf29382cff3af4cc926c9cd5e53beb6c9e5"
 dependencies = [
  "app_units",
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "cssparser",
  "euclid",
  "malloc_size_of_derive",
@@ -7014,7 +7283,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04d3973284ef0dc7362cdaee41c2356c4c39a5a5ebd8490c5163ebf21a7adc02"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "cfg_aliases",
  "cgl",
  "euclid",
@@ -7089,10 +7358,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "taffy"
-version = "0.9.2"
+name = "sys-locale"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ba83ebaf2954d31d05d67340fd46cebe99da2b7133b0dd68d70c65473a437b"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "taffy"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aea22054047c16c3f34d3ac473a2170be1424b1115b2a3adcf28cfb067c88859"
 dependencies = [
  "arrayvec",
  "grid",
@@ -7126,13 +7404,12 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
  "encoding_rs",
- "futf",
- "mac",
+ "new_debug_unreachable",
  "utf-8",
 ]
 
@@ -7141,6 +7418,16 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "textnonce"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f8d70cd784ed1dc33106a18998d77758d281dc40dc3e6d050cf0f5286683"
+dependencies = [
+ "base64 0.12.3",
+ "rand 0.7.3",
+]
 
 [[package]]
 name = "thin-vec"
@@ -7186,20 +7473,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tiff"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
-dependencies = [
- "fax",
- "flate2",
- "half",
- "quick-error",
- "weezl",
- "zune-jpeg 0.4.21",
 ]
 
 [[package]]
@@ -7253,16 +7526,6 @@ checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "timers"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "crossbeam-channel",
- "malloc_size_of_derive",
- "servo_malloc_size_of",
 ]
 
 [[package]]
@@ -7330,7 +7593,8 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab187810ca1e6aaa4c97a06492aac9ade2ffae6a301fd2aac103656f5a69edb"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7343,7 +7607,8 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba1f5563024b63bb6acb4558452d9ba737518c1d11fcc1861febe98d1e31cf4"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7487,9 +7752,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -7501,7 +7766,6 @@ dependencies = [
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]
@@ -7604,9 +7868,9 @@ checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-vo"
@@ -7619,6 +7883,18 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "universal-hash"
@@ -7714,11 +7990,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "sha1_smol",
@@ -7837,6 +8113,12 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
@@ -7846,6 +8128,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -7896,6 +8187,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "wayland-sys"
 version = "0.31.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7919,9 +8244,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e588f10c7bc3465f5fc1ab087fc97877ec1064a7ec89fb685ac4ee998dac4a"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
 dependencies = [
  "phf",
  "phf_codegen",
@@ -7953,64 +8278,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webgl"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "base",
- "bitflags 2.10.0",
- "byteorder",
- "canvas_traits",
- "compositing_traits",
- "crossbeam-channel",
- "euclid",
- "glow",
- "half",
- "itertools 0.14.0",
- "log",
- "parking_lot",
- "pixels",
- "rustc-hash 2.1.1",
- "surfman",
- "webrender",
- "webrender_api",
-]
-
-[[package]]
-name = "webgpu"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "arrayvec",
- "base",
- "compositing_traits",
- "euclid",
- "log",
- "pixels",
- "rustc-hash 2.1.1",
- "servo_config",
- "webgpu_traits",
- "webrender_api",
- "wgpu-core",
- "wgpu-types",
-]
-
-[[package]]
-name = "webgpu_traits"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "arrayvec",
- "base",
- "pixels",
- "serde",
- "servo_malloc_size_of",
- "webrender_api",
- "wgpu-core",
- "wgpu-types",
-]
-
-[[package]]
 name = "webpki-root-certs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8031,11 +8298,12 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.68.0"
-source = "git+https://github.com/servo/webrender?rev=6cafc606096db4715a6119a6e16391aed9af47a5#6cafc606096db4715a6119a6e16391aed9af47a5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a591c25221a9f8ac2ad7754659b283d912cee6c8424f0fa3777aabed3be91c16"
 dependencies = [
  "allocator-api2",
  "bincode",
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "build-parallel",
  "byteorder",
  "derive_more",
@@ -8051,7 +8319,7 @@ dependencies = [
  "plane-split",
  "rayon",
  "ron",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "serde",
  "smallvec",
  "svg_fmt",
@@ -8067,10 +8335,11 @@ dependencies = [
 [[package]]
 name = "webrender_api"
 version = "0.68.0"
-source = "git+https://github.com/servo/webrender?rev=6cafc606096db4715a6119a6e16391aed9af47a5#6cafc606096db4715a6119a6e16391aed9af47a5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb206f613b4635881065a2ff4670e656edc904af0b8729c51ce1196679fd1b6d"
 dependencies = [
  "app_units",
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "byteorder",
  "crossbeam-channel",
  "euclid",
@@ -8085,44 +8354,12 @@ dependencies = [
 
 [[package]]
 name = "webrender_build"
-version = "0.0.2"
-source = "git+https://github.com/servo/webrender?rev=6cafc606096db4715a6119a6e16391aed9af47a5#6cafc606096db4715a6119a6e16391aed9af47a5"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6165a81201892371061250bd6f08ede9ed7279842fedc4033f48582a789068"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "lazy_static",
-]
-
-[[package]]
-name = "webxr"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "base",
- "crossbeam-channel",
- "euclid",
- "glow",
- "log",
- "openxr",
- "profile_traits",
- "raw-window-handle",
- "surfman",
- "webxr-api",
- "winapi",
- "wio",
-]
-
-[[package]]
-name = "webxr-api"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "base",
- "embedder_traits",
- "euclid",
- "ipc-channel",
- "log",
- "profile_traits",
- "serde",
 ]
 
 [[package]]
@@ -8140,7 +8377,7 @@ dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "cfg_aliases",
  "document-features",
  "hashbrown 0.15.5",
@@ -8198,7 +8435,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "block",
  "bytemuck",
  "cfg-if",
@@ -8239,7 +8476,7 @@ version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eca7a8d8af57c18f57d393601a1fb159ace8b2328f1b6b5f80893f7d672c9ae2"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "bytemuck",
  "js-sys",
  "log",
@@ -8727,11 +8964,94 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "wr_glyph_rasterizer"
-version = "0.1.0"
-source = "git+https://github.com/servo/webrender?rev=6cafc606096db4715a6119a6e16391aed9af47a5#6cafc606096db4715a6119a6e16391aed9af47a5"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4fcffa889d25131fc7c6ec8a558aa7c78d6030eaa17e31695c172adcc4eb0b"
 dependencies = [
  "core-foundation 0.9.4",
  "core-graphics",
@@ -8745,7 +9065,7 @@ dependencies = [
  "malloc_size_of_derive",
  "objc",
  "rayon",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "serde",
  "smallvec",
  "tracy-rs",
@@ -8756,7 +9076,8 @@ dependencies = [
 [[package]]
 name = "wr_malloc_size_of"
 version = "0.2.2"
-source = "git+https://github.com/servo/webrender?rev=6cafc606096db4715a6119a6e16391aed9af47a5#6cafc606096db4715a6119a6e16391aed9af47a5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482308b684f11723b200a32808094bb460b5ac4840903ccbcb78ad92a6354a1f"
 dependencies = [
  "app_units",
  "euclid",
@@ -8793,23 +9114,6 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
-
-[[package]]
-name = "x11rb"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
-dependencies = [
- "gethostname",
- "rustix",
- "x11rb-protocol",
-]
-
-[[package]]
-name = "x11rb-protocol"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "x25519-dalek"
@@ -8853,9 +9157,9 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xml5ever"
-version = "0.36.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f57dd51b88a4b9f99f9b55b136abb86210629d61c48117ddb87f567e51e66be7"
+checksum = "5ab627f34ff61b80d756180d556f9c68801d836d271b3b8c094504ceca69d221"
 dependencies = [
  "log",
  "markup5ever",
@@ -8866,17 +9170,6 @@ name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
-
-[[package]]
-name = "xpath"
-version = "0.0.1"
-source = "git+https://github.com/servo/servo?branch=main#93a22ffd71c738221c500a7fd4963385ca907af7"
-dependencies = [
- "log",
- "malloc_size_of_derive",
- "markup5ever",
- "servo_malloc_size_of",
-]
 
 [[package]]
 name = "y4m"

--- a/mech_posix/Cargo.toml
+++ b/mech_posix/Cargo.toml
@@ -14,22 +14,33 @@ path = "src/main.rs"
 [[bin]]
 name = "mechd"
 path = "src/mechd.rs"
+required-features = ["daemon"]
+
+[features]
+default = ["daemon"]
+# Enables the Servo-backed `mechd` daemon. Disabled when running lib tests so
+# that `cargo test --lib --no-default-features` skips Servo entirely.
+daemon = ["dep:servo", "dep:dpi", "dep:url", "dep:libc", "dep:rustls"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "4.0", features = ["derive"] }
 
-# Servo browser engine for headless operation (used by mechd)
-servo = { git = "https://github.com/servo/servo", branch = "main", package = "libservo" }
-dpi = "0.1"
-url = "2.5"
-libc = "0.2"
-
-# Force rustls to enable aws_lc_rs feature for Servo compatibility
-rustls = { version = "0.23", features = ["aws_lc_rs"] }
+# Daemon-only dependencies — gated behind the `daemon` feature so the lib and
+# the `mech` client can be built/tested without pulling in Servo's dep tree.
+servo = { version = "0.1", default-features = false, features = ["baked-in-resources", "js_jit"], optional = true }
+dpi = { version = "0.1", optional = true }
+url = { version = "2.5", optional = true }
+libc = { version = "0.2", optional = true }
+# Forces aws_lc_rs for Servo compatibility.
+rustls = { version = "0.23", features = ["aws_lc_rs"], optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.0"
 predicates = "3.0"
 tempfile = "3.0"
+
+# Stop Servo taking up so much disk space
+[profile.dev.package."*"]
+debug = false

--- a/mech_posix/com.hypermap.mech.varlink
+++ b/mech_posix/com.hypermap.mech.varlink
@@ -1,0 +1,39 @@
+# Interface for the mech daemon (mechd).
+#
+# The mech CLI communicates with mechd over a Unix socket using the varlink
+# protocol: JSON messages framed with null-byte delimiters.
+
+interface com.hypermap.mech
+
+# Open a URL in a new tab.
+method Open(url: string, name: ?string) -> (message: string)
+
+# Show tab contents, optionally at a specific path.
+method Show(tab: string, path: ?string, color: bool) -> (message: string)
+
+# Set a value at a path without triggering the control.
+method Set(tab: string, path: string, value: string) -> ()
+
+# Activate a control at a path, optionally with form data.
+method Use(tab: string, path: string, data: [string]string) -> ()
+
+# Fork (copy) a tab.
+method Fork(tab: string, name: ?string) -> (message: string)
+
+# Close a tab.
+method Close(tab: string) -> (message: string)
+
+# Rename a tab.
+method Name(tab: string, name: string) -> (message: string)
+
+# List all open tabs.
+method Tabs() -> (message: string)
+
+# Shut down the daemon.
+method Shutdown() -> ()
+
+error TabNotFound(tab: string)
+error PathNotFound(tab: string, path: string)
+error NameInUse(name: string)
+error InvalidUrl(url: string, reason: string)
+error PageError(message: string)

--- a/mech_posix/src/lib.rs
+++ b/mech_posix/src/lib.rs
@@ -1,10 +1,15 @@
 // Shared types and utilities for mech CLI
 //
 // This module contains code shared between the mech client and mechd daemon.
+// Communication uses the varlink protocol: JSON messages over a Unix socket,
+// framed with null byte (\0) delimiters.
 
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
 use std::fmt::Write;
 use std::fs;
+use std::io;
 
 pub fn socket_path() -> String {
     std::env::var("MECH_SOCKET_PATH").unwrap_or_else(|_| "/tmp/mech.sock".to_string())
@@ -19,8 +24,50 @@ pub fn cleanup() {
     let _ = fs::remove_file(pid_path());
 }
 
-/// Daemon protocol commands (sent over socket)
-#[derive(Debug, Clone)]
+// -- Varlink framing ----------------------------------------------------------
+
+/// Write a varlink message: JSON bytes followed by a null byte.
+pub fn write_message(writer: &mut impl io::Write, msg: &[u8]) -> io::Result<()> {
+    writer.write_all(msg)?;
+    writer.write_all(&[0])?;
+    writer.flush()
+}
+
+/// Read a varlink message: consume bytes until a null byte or EOF.
+pub fn read_message(reader: &mut impl io::Read) -> io::Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    let mut byte = [0u8; 1];
+    loop {
+        match reader.read(&mut byte) {
+            Ok(0) => {
+                if buf.is_empty() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "connection closed",
+                    ));
+                }
+                break;
+            }
+            Ok(_) => {
+                if byte[0] == 0 {
+                    break;
+                }
+                buf.push(byte[0]);
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(buf)
+}
+
+// -- Protocol types -----------------------------------------------------------
+
+/// Daemon protocol commands (varlink methods).
+///
+/// Serializes as `{"method": "Open", "parameters": {"url": "..."}}` which
+/// matches the varlink wire format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "method", content = "parameters")]
 pub enum DaemonCommand {
     Open {
         url: String,
@@ -39,7 +86,7 @@ pub enum DaemonCommand {
     Use {
         tab: String,
         path: String,
-        data: Vec<(String, String)>,
+        data: HashMap<String, String>,
     },
     Fork {
         tab: String,
@@ -56,98 +103,75 @@ pub enum DaemonCommand {
     Shutdown,
 }
 
-pub fn parse_command(input: &str) -> Option<DaemonCommand> {
-    let parts: Vec<&str> = input.split_whitespace().collect();
-    let cmd = *parts.first()?;
+/// Daemon error variants (varlink errors).
+///
+/// Serializes as `{"error": "TabNotFound", "parameters": {"tab": "1"}}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "error", content = "parameters")]
+pub enum DaemonError {
+    TabNotFound { tab: String },
+    PathNotFound { tab: String, path: String },
+    NameInUse { name: String },
+    InvalidUrl { url: String, reason: String },
+    PageError { message: String },
+}
 
-    match cmd {
-        "open" => {
-            // open <url> [--name <name>]
-            let mut url = String::new();
-            let mut name = None;
-            let mut i = 1;
-            while i < parts.len() {
-                if parts[i] == "--name" && i + 1 < parts.len() {
-                    name = Some(parts[i + 1].to_string());
-                    i += 2;
-                } else {
-                    if !url.is_empty() {
-                        url.push(' ');
-                    }
-                    url.push_str(parts[i]);
-                    i += 1;
-                }
+impl DaemonError {
+    /// Human-readable rendering for the CLI to print to stderr.
+    pub fn user_message(&self) -> String {
+        match self {
+            DaemonError::TabNotFound { tab } => format!("Tab '{}' not found", tab),
+            DaemonError::PathNotFound { tab, path } => {
+                format!("Path '{}' not found in tab '{}'", path, tab)
             }
-            Some(DaemonCommand::Open { url, name })
-        }
-        "show" => {
-            // show <tab> [path] [--color]
-            let tab = parts.get(1)?.to_string();
-            let color = parts.contains(&"--color");
-            let path_parts: Vec<&str> = parts[2..]
-                .iter()
-                .filter(|&&p| p != "--color")
-                .copied()
-                .collect();
-            let path = if path_parts.is_empty() {
-                None
-            } else {
-                Some(path_parts.join("/"))
-            };
-            Some(DaemonCommand::Show { tab, path, color })
-        }
-        "set" => {
-            // set <tab> <path> <value>
-            let tab = parts.get(1)?.to_string();
-            let path = parts.get(2)?.to_string();
-            let value = parts.get(3)?.to_string();
-            Some(DaemonCommand::Set { tab, path, value })
-        }
-        "use" => {
-            // use <tab> <path> [key=value ...]
-            let tab = parts.get(1)?.to_string();
-            let path = parts.get(2)?.to_string();
-            let data = parts[3..]
-                .iter()
-                .filter_map(|s| {
-                    let mut split = s.splitn(2, '=');
-                    Some((split.next()?.to_string(), split.next()?.to_string()))
-                })
-                .collect();
-            Some(DaemonCommand::Use { tab, path, data })
-        }
-        "fork" => {
-            // fork <tab> [--name <name>]
-            let tab = parts.get(1)?.to_string();
-            let mut name = None;
-            let mut i = 2;
-            while i < parts.len() {
-                if parts[i] == "--name" && i + 1 < parts.len() {
-                    name = Some(parts[i + 1].to_string());
-                    i += 2;
-                } else {
-                    i += 1;
-                }
+            DaemonError::NameInUse { name } => format!("Tab name '{}' already in use", name),
+            DaemonError::InvalidUrl { url, reason } => {
+                format!("Invalid URL '{}': {}", url, reason)
             }
-            Some(DaemonCommand::Fork { tab, name })
+            DaemonError::PageError { message } => message.trim_end().to_string(),
         }
-        "close" => {
-            let tab = parts.get(1)?.to_string();
-            Some(DaemonCommand::Close { tab })
+    }
+}
+
+/// Successful response parameters.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DaemonOk {
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub message: String,
+}
+
+/// Daemon reply (varlink reply).
+///
+/// On success: `{"parameters": {"message": "..."}}` (or `{"parameters": {}}` for unit returns).
+/// On error: `{"error": "TabNotFound", "parameters": {"tab": "1"}}`.
+///
+/// `Err` is tried first when deserializing untagged: it requires a top-level
+/// `error` field, so success replies fall through to the `Ok` variant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DaemonReply {
+    Err(DaemonError),
+    Ok { parameters: DaemonOk },
+}
+
+impl DaemonReply {
+    pub fn ok() -> Self {
+        DaemonReply::Ok {
+            parameters: DaemonOk::default(),
         }
-        "name" => {
-            let tab = parts.get(1)?.to_string();
-            let name = parts.get(2)?.to_string();
-            Some(DaemonCommand::Name { tab, name })
+    }
+
+    pub fn ok_message(message: impl Into<String>) -> Self {
+        DaemonReply::Ok {
+            parameters: DaemonOk {
+                message: message.into(),
+            },
         }
-        "tabs" => Some(DaemonCommand::Tabs),
-        "shutdown" => Some(DaemonCommand::Shutdown),
-        _ => None,
     }
 }
 
 #[cfg(test)]
-fn format_hypermap(value: &Value, indent: usize) -> String {
+pub fn format_hypermap(value: &Value, indent: usize) -> String {
     format_hypermap_styled(value, indent, false)
 }
 
@@ -258,187 +282,291 @@ fn format_hypermap_recursive(value: &Value, indent: usize, output: &mut String, 
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::io::Cursor;
 
-    // parse_command tests
+    // -- Roundtrip serialization tests ----------------------------------------
 
-    #[test]
-    fn parse_command_open() {
-        let cmd = parse_command("open https://example.com").unwrap();
-        assert!(
-            matches!(cmd, DaemonCommand::Open { ref url, name: None } if url == "https://example.com")
-        );
+    fn roundtrip(cmd: &DaemonCommand) -> DaemonCommand {
+        let json = serde_json::to_vec(cmd).unwrap();
+        serde_json::from_slice(&json).unwrap()
     }
 
     #[test]
-    fn parse_command_open_with_name() {
-        let cmd = parse_command("open https://example.com --name myapp").unwrap();
-        assert!(
-            matches!(cmd, DaemonCommand::Open { ref url, ref name } if url == "https://example.com" && name.as_deref() == Some("myapp"))
-        );
+    fn roundtrip_open() {
+        let cmd = DaemonCommand::Open {
+            url: "https://example.com".into(),
+            name: None,
+        };
+        assert!(matches!(
+            roundtrip(&cmd),
+            DaemonCommand::Open { ref url, name: None } if url == "https://example.com"
+        ));
     }
 
     #[test]
-    fn parse_command_open_with_spaces() {
-        let cmd = parse_command("open https://example.com/path with spaces").unwrap();
-        assert!(
-            matches!(cmd, DaemonCommand::Open { ref url, .. } if url == "https://example.com/path with spaces")
-        );
+    fn roundtrip_open_with_name() {
+        let cmd = DaemonCommand::Open {
+            url: "https://example.com".into(),
+            name: Some("myapp".into()),
+        };
+        assert!(matches!(
+            roundtrip(&cmd),
+            DaemonCommand::Open { ref url, ref name }
+                if url == "https://example.com" && name.as_deref() == Some("myapp")
+        ));
     }
 
     #[test]
-    fn parse_command_show() {
-        let cmd = parse_command("show 1").unwrap();
-        assert!(
-            matches!(cmd, DaemonCommand::Show { ref tab, path: None, color: false } if tab == "1")
-        );
+    fn roundtrip_show() {
+        let cmd = DaemonCommand::Show {
+            tab: "1".into(),
+            path: Some("nav/home".into()),
+            color: true,
+        };
+        assert!(matches!(
+            roundtrip(&cmd),
+            DaemonCommand::Show { ref tab, ref path, color: true }
+                if tab == "1" && path.as_deref() == Some("nav/home")
+        ));
     }
 
     #[test]
-    fn parse_command_show_with_path() {
-        let cmd = parse_command("show 1 nav/home").unwrap();
-        assert!(
-            matches!(cmd, DaemonCommand::Show { ref tab, ref path, color: false } if tab == "1" && path.as_deref() == Some("nav/home"))
-        );
-    }
-
-    #[test]
-    fn parse_command_show_with_color() {
-        let cmd = parse_command("show 1 --color").unwrap();
-        assert!(
-            matches!(cmd, DaemonCommand::Show { ref tab, path: None, color: true } if tab == "1")
-        );
-    }
-
-    #[test]
-    fn parse_command_show_with_path_and_color() {
-        let cmd = parse_command("show 1 nav/home --color").unwrap();
-        assert!(
-            matches!(cmd, DaemonCommand::Show { ref tab, ref path, color: true } if tab == "1" && path.as_deref() == Some("nav/home"))
-        );
-    }
-
-    #[test]
-    fn parse_command_set() {
-        let cmd = parse_command("set 1 market/ibm/quantity 100").unwrap();
-        if let DaemonCommand::Set { tab, path, value } = cmd {
+    fn roundtrip_set() {
+        let cmd = DaemonCommand::Set {
+            tab: "1".into(),
+            path: "market/ibm/quantity".into(),
+            value: "100".into(),
+        };
+        if let DaemonCommand::Set { tab, path, value } = roundtrip(&cmd) {
             assert_eq!(tab, "1");
             assert_eq!(path, "market/ibm/quantity");
             assert_eq!(value, "100");
         } else {
-            panic!("Expected Set command");
+            panic!("Expected Set");
         }
     }
 
     #[test]
-    fn parse_command_use() {
-        let cmd = parse_command("use 1 nav/home").unwrap();
-        assert!(
-            matches!(cmd, DaemonCommand::Use { ref tab, ref path, .. } if tab == "1" && path == "nav/home")
-        );
-    }
-
-    #[test]
-    fn parse_command_use_with_data() {
-        let cmd = parse_command("use 1 submit quantity=5").unwrap();
-        if let DaemonCommand::Use { tab, path, data } = cmd {
+    fn roundtrip_use_with_data() {
+        let mut data = HashMap::new();
+        data.insert("quantity".into(), "5".into());
+        let cmd = DaemonCommand::Use {
+            tab: "1".into(),
+            path: "submit".into(),
+            data,
+        };
+        if let DaemonCommand::Use { tab, path, data } = roundtrip(&cmd) {
             assert_eq!(tab, "1");
             assert_eq!(path, "submit");
-            assert_eq!(data, vec![("quantity".to_string(), "5".to_string())]);
+            assert_eq!(data.get("quantity"), Some(&"5".to_string()));
+            assert_eq!(data.len(), 1);
         } else {
-            panic!("Expected Use command");
+            panic!("Expected Use");
         }
     }
 
     #[test]
-    fn parse_command_fork() {
-        let cmd = parse_command("fork 1").unwrap();
-        if let DaemonCommand::Fork { tab, name } = cmd {
-            assert_eq!(tab, "1");
-            assert_eq!(name, None);
-        } else {
-            panic!("Expected Fork command");
+    fn use_data_serializes_as_json_object() {
+        let mut data = HashMap::new();
+        data.insert("quantity".into(), "5".into());
+        data.insert("symbol".into(), "IBM".into());
+        let cmd = DaemonCommand::Use {
+            tab: "1".into(),
+            path: "submit".into(),
+            data,
+        };
+        let val: Value = serde_json::to_value(&cmd).unwrap();
+        let params = &val["parameters"];
+        assert!(params["data"].is_object());
+        assert_eq!(params["data"]["quantity"], "5");
+        assert_eq!(params["data"]["symbol"], "IBM");
+    }
+
+    #[test]
+    fn roundtrip_fork() {
+        let cmd = DaemonCommand::Fork {
+            tab: "stocks".into(),
+            name: Some("stocks2".into()),
+        };
+        assert!(matches!(
+            roundtrip(&cmd),
+            DaemonCommand::Fork { ref tab, ref name }
+                if tab == "stocks" && name.as_deref() == Some("stocks2")
+        ));
+    }
+
+    #[test]
+    fn roundtrip_close() {
+        let cmd = DaemonCommand::Close {
+            tab: "2".into(),
+        };
+        assert!(matches!(roundtrip(&cmd), DaemonCommand::Close { ref tab } if tab == "2"));
+    }
+
+    #[test]
+    fn roundtrip_name() {
+        let cmd = DaemonCommand::Name {
+            tab: "1".into(),
+            name: "stocks".into(),
+        };
+        assert!(matches!(
+            roundtrip(&cmd),
+            DaemonCommand::Name { ref tab, ref name } if tab == "1" && name == "stocks"
+        ));
+    }
+
+    #[test]
+    fn roundtrip_tabs() {
+        assert!(matches!(roundtrip(&DaemonCommand::Tabs), DaemonCommand::Tabs));
+    }
+
+    #[test]
+    fn roundtrip_shutdown() {
+        assert!(matches!(
+            roundtrip(&DaemonCommand::Shutdown),
+            DaemonCommand::Shutdown
+        ));
+    }
+
+    #[test]
+    fn json_shape_matches_varlink() {
+        let cmd = DaemonCommand::Open {
+            url: "https://example.com".into(),
+            name: None,
+        };
+        let val: Value = serde_json::to_value(&cmd).unwrap();
+        assert_eq!(val["method"], "Open");
+        assert!(val["parameters"].is_object());
+    }
+
+    #[test]
+    fn json_shape_unit_variant() {
+        let val: Value = serde_json::to_value(&DaemonCommand::Tabs).unwrap();
+        assert_eq!(val["method"], "Tabs");
+        // Unit variants have no "parameters" key
+        assert!(val.get("parameters").is_none());
+    }
+
+    // -- Framing tests --------------------------------------------------------
+
+    #[test]
+    fn framing_roundtrip() {
+        let msg = b"hello";
+        let mut buf = Vec::new();
+        write_message(&mut buf, msg).unwrap();
+        assert_eq!(buf, b"hello\0");
+
+        let mut reader = Cursor::new(buf);
+        let read_back = read_message(&mut reader).unwrap();
+        assert_eq!(read_back, b"hello");
+    }
+
+    #[test]
+    fn framing_empty_stream() {
+        let mut reader = Cursor::new(Vec::<u8>::new());
+        assert!(read_message(&mut reader).is_err());
+    }
+
+    #[test]
+    fn framing_eof_without_null() {
+        // Data without null terminator — read_message returns data at EOF
+        let mut reader = Cursor::new(b"partial".to_vec());
+        let msg = read_message(&mut reader).unwrap();
+        assert_eq!(msg, b"partial");
+    }
+
+    // -- Reply tests ----------------------------------------------------------
+
+    #[test]
+    fn reply_ok_roundtrip() {
+        let reply = DaemonReply::ok_message("Opened tab 1");
+        let json = serde_json::to_vec(&reply).unwrap();
+        let parsed: DaemonReply = serde_json::from_slice(&json).unwrap();
+        match parsed {
+            DaemonReply::Ok { parameters } => assert_eq!(parameters.message, "Opened tab 1"),
+            DaemonReply::Err(_) => panic!("Expected Ok"),
         }
     }
 
     #[test]
-    fn parse_command_fork_with_name() {
-        let cmd = parse_command("fork 1 --name copy").unwrap();
-        if let DaemonCommand::Fork { tab, name } = cmd {
-            assert_eq!(tab, "1");
-            assert_eq!(name, Some("copy".to_string()));
-        } else {
-            panic!("Expected Fork command");
+    fn reply_ok_wire_shape() {
+        let val: Value = serde_json::to_value(DaemonReply::ok_message("Opened tab 1")).unwrap();
+        assert!(val.get("error").is_none());
+        assert_eq!(val["parameters"]["message"], "Opened tab 1");
+    }
+
+    #[test]
+    fn reply_ok_empty_omits_message() {
+        let val: Value = serde_json::to_value(DaemonReply::ok()).unwrap();
+        // Unit-return methods (`-> ()`) serialize as `{"parameters": {}}`.
+        assert!(val["parameters"].is_object());
+        assert_eq!(val["parameters"].as_object().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn reply_error_roundtrip() {
+        let reply = DaemonReply::Err(DaemonError::TabNotFound { tab: "1".into() });
+        let json = serde_json::to_vec(&reply).unwrap();
+        let parsed: DaemonReply = serde_json::from_slice(&json).unwrap();
+        match parsed {
+            DaemonReply::Err(DaemonError::TabNotFound { tab }) => assert_eq!(tab, "1"),
+            _ => panic!("Expected TabNotFound"),
         }
     }
 
     #[test]
-    fn parse_command_fork_by_name() {
-        let cmd = parse_command("fork stocks --name stocks2").unwrap();
-        if let DaemonCommand::Fork { tab, name } = cmd {
-            assert_eq!(tab, "stocks");
-            assert_eq!(name, Some("stocks2".to_string()));
-        } else {
-            panic!("Expected Fork command");
+    fn reply_error_wire_shape() {
+        let reply = DaemonReply::Err(DaemonError::InvalidUrl {
+            url: "bogus".into(),
+            reason: "no scheme".into(),
+        });
+        let val: Value = serde_json::to_value(&reply).unwrap();
+        assert_eq!(val["error"], "InvalidUrl");
+        assert_eq!(val["parameters"]["url"], "bogus");
+        assert_eq!(val["parameters"]["reason"], "no scheme");
+    }
+
+    #[test]
+    fn reply_distinguishes_ok_from_err() {
+        let err_json = r#"{"error": "TabNotFound", "parameters": {"tab": "1"}}"#;
+        let parsed: DaemonReply = serde_json::from_str(err_json).unwrap();
+        assert!(matches!(parsed, DaemonReply::Err(DaemonError::TabNotFound { .. })));
+
+        let ok_json = r#"{"parameters": {"message": "hi"}}"#;
+        let parsed: DaemonReply = serde_json::from_str(ok_json).unwrap();
+        assert!(matches!(parsed, DaemonReply::Ok { .. }));
+    }
+
+    #[test]
+    fn reply_ok_unit_parses_from_empty_parameters() {
+        let parsed: DaemonReply = serde_json::from_str(r#"{"parameters": {}}"#).unwrap();
+        match parsed {
+            DaemonReply::Ok { parameters } => assert_eq!(parameters.message, ""),
+            DaemonReply::Err(_) => panic!("Expected Ok"),
         }
     }
 
     #[test]
-    fn parse_command_close() {
-        let cmd = parse_command("close 2").unwrap();
-        assert!(matches!(cmd, DaemonCommand::Close { ref tab } if tab == "2"));
-    }
-
-    #[test]
-    fn parse_command_close_by_name() {
-        let cmd = parse_command("close myapp").unwrap();
-        assert!(matches!(cmd, DaemonCommand::Close { ref tab } if tab == "myapp"));
-    }
-
-    #[test]
-    fn parse_command_name() {
-        let cmd = parse_command("name 1 stocks").unwrap();
-        assert!(
-            matches!(cmd, DaemonCommand::Name { ref tab, ref name } if tab == "1" && name == "stocks")
+    fn error_user_messages() {
+        assert_eq!(
+            DaemonError::TabNotFound { tab: "1".into() }.user_message(),
+            "Tab '1' not found"
+        );
+        assert_eq!(
+            DaemonError::PathNotFound {
+                tab: "1".into(),
+                path: "nav/home".into()
+            }
+            .user_message(),
+            "Path 'nav/home' not found in tab '1'"
+        );
+        assert_eq!(
+            DaemonError::NameInUse { name: "stocks".into() }.user_message(),
+            "Tab name 'stocks' already in use"
         );
     }
 
-    #[test]
-    fn parse_command_tabs() {
-        let cmd = parse_command("tabs").unwrap();
-        assert!(matches!(cmd, DaemonCommand::Tabs));
-    }
-
-    #[test]
-    fn parse_command_shutdown() {
-        let cmd = parse_command("shutdown").unwrap();
-        assert!(matches!(cmd, DaemonCommand::Shutdown));
-    }
-
-    #[test]
-    fn parse_command_empty() {
-        assert!(parse_command("").is_none());
-    }
-
-    #[test]
-    fn parse_command_unknown() {
-        assert!(parse_command("unknown").is_none());
-    }
-
-    #[test]
-    fn parse_command_open_missing_url() {
-        // Currently returns empty string URL, which is valid
-        let cmd = parse_command("open").unwrap();
-        assert!(matches!(cmd, DaemonCommand::Open { ref url, .. } if url.is_empty()));
-    }
-
-    #[test]
-    fn parse_command_show_by_name() {
-        // show now accepts tab references (name or index)
-        let cmd = parse_command("show myapp").unwrap();
-        assert!(matches!(cmd, DaemonCommand::Show { ref tab, .. } if tab == "myapp"));
-    }
-
-    // format_hypermap tests
+    // -- format_hypermap tests ------------------------------------------------
 
     #[test]
     fn format_hypermap_simple_value() {

--- a/mech_posix/src/main.rs
+++ b/mech_posix/src/main.rs
@@ -1,14 +1,15 @@
 // mech - CLI client for interacting with HyperMap resources
 //
 // This is the lightweight client binary. It communicates with the mechd daemon
-// over a Unix socket to manage tabs and navigate HyperMap resources.
+// over a Unix socket using the varlink protocol (JSON + null-byte framing).
 
 use clap::{Parser, Subcommand};
-use std::io::{IsTerminal, Read, Write};
+use std::collections::HashMap;
+use std::io::{IsTerminal, Read};
 use std::os::unix::net::UnixStream;
 use std::process::Command;
 
-use mech_cli::{cleanup, socket_path};
+use mech_cli::{cleanup, socket_path, write_message, DaemonCommand, DaemonReply};
 
 #[cfg(test)]
 use mech_cli::format_hypermap_styled;
@@ -97,20 +98,12 @@ fn main() {
         Commands::Start { foreground } => start_daemon(foreground),
         Commands::Stop => stop_daemon(),
         Commands::Open { url, name } => {
-            let name_part = name.map(|n| format!(" --name {}", n)).unwrap_or_default();
-            send_command(&format!("open {}{}", url, name_part));
+            send_command(&DaemonCommand::Open { url, name });
         }
         Commands::Show { target } => {
             let (tab, path) = parse_target(&target);
-            let color_flag = if std::io::stdout().is_terminal() {
-                " --color"
-            } else {
-                ""
-            };
-            match path {
-                Some(p) => send_command(&format!("show {} {}{}", tab, p, color_flag)),
-                None => send_command(&format!("show {}{}", tab, color_flag)),
-            }
+            let color = std::io::stdout().is_terminal();
+            send_command(&DaemonCommand::Show { tab, path, color });
         }
         Commands::Set { target, value } => {
             let (tab, path) = parse_target(&target);
@@ -118,7 +111,7 @@ fn main() {
                 eprintln!("error: set requires a path (e.g., \"{}:path/to/field\")", tab);
                 std::process::exit(1);
             };
-            send_command(&format!("set {} {} {}", tab, path, value));
+            send_command(&DaemonCommand::Set { tab, path, value });
         }
         Commands::Use { target, data } => {
             let (tab, path) = parse_target(&target);
@@ -126,21 +119,26 @@ fn main() {
                 eprintln!("error: use requires a path (e.g., \"{}:path/to/control\")", tab);
                 std::process::exit(1);
             };
-            let data_str = data.join(" ");
-            send_command(&format!("use {} {} {}", tab, path, data_str));
+            let data: HashMap<String, String> = data
+                .iter()
+                .filter_map(|s| {
+                    let mut split = s.splitn(2, '=');
+                    Some((split.next()?.to_string(), split.next()?.to_string()))
+                })
+                .collect();
+            send_command(&DaemonCommand::Use { tab, path, data });
         }
         Commands::Fork { tab, name } => {
-            let name_part = name.map(|n| format!(" --name {}", n)).unwrap_or_default();
-            send_command(&format!("fork {}{}", tab, name_part));
+            send_command(&DaemonCommand::Fork { tab, name });
         }
         Commands::Close { tab } => {
-            send_command(&format!("close {}", tab));
+            send_command(&DaemonCommand::Close { tab });
         }
         Commands::Name { tab, name } => {
-            send_command(&format!("name {} {}", tab, name));
+            send_command(&DaemonCommand::Name { tab, name });
         }
         Commands::Tabs => {
-            send_command("tabs");
+            send_command(&DaemonCommand::Tabs);
         }
     }
 }
@@ -157,19 +155,35 @@ fn parse_target(target: &str) -> (String, Option<String>) {
     }
 }
 
-fn send_command(cmd: &str) {
+fn send_command(cmd: &DaemonCommand) {
     match UnixStream::connect(socket_path()) {
         Ok(mut stream) => {
-            if let Err(e) = stream.write_all(cmd.as_bytes()) {
+            let json = serde_json::to_vec(cmd).expect("Failed to serialize command");
+            if let Err(e) = write_message(&mut stream, &json) {
                 eprintln!("Failed to send command: {}", e);
                 return;
             }
-            // Shutdown write side to signal end of command
             let _ = stream.shutdown(std::net::Shutdown::Write);
-            // Read response
-            let mut response = String::new();
-            if stream.read_to_string(&mut response).is_ok() && !response.is_empty() {
-                print!("{}", response);
+            let mut buf = Vec::new();
+            if stream.read_to_end(&mut buf).is_ok() && !buf.is_empty() {
+                if buf.last() == Some(&0) {
+                    buf.pop();
+                }
+                match serde_json::from_slice::<DaemonReply>(&buf) {
+                    Ok(DaemonReply::Ok { parameters }) => {
+                        if !parameters.message.is_empty() {
+                            print!("{}", parameters.message);
+                        }
+                    }
+                    Ok(DaemonReply::Err(err)) => {
+                        eprintln!("{}", err.user_message());
+                        std::process::exit(1);
+                    }
+                    Err(_) => {
+                        eprintln!("Invalid response from daemon. Is mechd up to date?");
+                        std::process::exit(1);
+                    }
+                }
             }
         }
         Err(_) => {
@@ -187,7 +201,7 @@ fn start_daemon(foreground: bool) {
 
     println!("Starting mech daemon...");
 
-    // Spawn mechd
+    // Spawn mechd from PATH
     let mut cmd = Command::new("mechd");
     if foreground {
         cmd.arg("--foreground");
@@ -224,15 +238,17 @@ fn start_daemon(foreground: bool) {
 }
 
 fn stop_daemon() {
-    send_command("shutdown");
+    if UnixStream::connect(socket_path()).is_err() {
+        // No daemon listening — just clean up stale files
+        cleanup();
+        eprintln!("Daemon is not running");
+        return;
+    }
+    send_command(&DaemonCommand::Shutdown);
     std::thread::sleep(std::time::Duration::from_millis(500));
     cleanup();
     println!("Daemon stopped");
 }
-
-// Re-export for tests that need these
-#[cfg(test)]
-pub use mech_cli::{parse_command, DaemonCommand};
 
 #[cfg(test)]
 mod tests {

--- a/mech_posix/src/mechd.rs
+++ b/mech_posix/src/mechd.rs
@@ -8,7 +8,6 @@ use serde_json::Value;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs::{self, File};
-use std::io::{Read, Write};
 use std::os::fd::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::process;
@@ -22,7 +21,10 @@ use servo::{
 };
 use url::Url;
 
-use mech_cli::{cleanup, format_hypermap_styled, parse_command, pid_path, socket_path, DaemonCommand};
+use mech_cli::{
+    cleanup, format_hypermap_styled, pid_path, read_message, socket_path, write_message,
+    DaemonCommand, DaemonError, DaemonReply,
+};
 
 #[derive(Parser)]
 #[command(name = "mechd", about = "Mech daemon - headless browser backend")]
@@ -71,7 +73,7 @@ struct DaemonState {
     tabs: Vec<Tab>,
     tab_counter: usize,
     #[allow(dead_code)]
-    pending_responses: HashMap<usize, mpsc::Sender<String>>,
+    pending_responses: HashMap<usize, mpsc::Sender<DaemonReply>>,
 }
 
 /// Delegate for handling Servo-level events
@@ -187,7 +189,7 @@ fn start_daemon(foreground: bool) {
     }));
 
     // Start socket listener thread
-    let (cmd_tx, cmd_rx) = mpsc::channel::<(DaemonCommand, mpsc::Sender<String>)>();
+    let (cmd_tx, cmd_rx) = mpsc::channel::<(DaemonCommand, mpsc::Sender<DaemonReply>)>();
     std::thread::spawn(move || {
         socket_listener(cmd_tx);
     });
@@ -215,24 +217,43 @@ fn start_daemon(foreground: bool) {
     }
 }
 
-fn socket_listener(cmd_tx: mpsc::Sender<(DaemonCommand, mpsc::Sender<String>)>) {
+fn socket_listener(cmd_tx: mpsc::Sender<(DaemonCommand, mpsc::Sender<DaemonReply>)>) {
     let listener = UnixListener::bind(socket_path()).expect("Failed to bind socket");
 
     for stream in listener.incoming() {
         match stream {
             Ok(mut stream) => {
-                let mut buffer = String::new();
-                if stream.read_to_string(&mut buffer).is_ok()
-                    && let Some(cmd) = parse_command(&buffer)
-                {
-                    let (tx, rx) = mpsc::channel();
-                    let _ = cmd_tx.send((cmd, tx));
-
-                    // Wait for response
-                    if let Ok(response) = rx.recv() {
-                        let _ = stream.write_all(response.as_bytes());
-                        let _ = stream.shutdown(std::net::Shutdown::Write);
+                let msg = match read_message(&mut stream) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        eprintln!("Failed to read message: {}", e);
+                        continue;
                     }
+                };
+
+                let cmd: DaemonCommand = match serde_json::from_slice(&msg) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("Invalid command: {}", e);
+                        let reply = DaemonReply::Err(DaemonError::PageError {
+                            message: format!("Protocol error: {}. Is mechd up to date?", e),
+                        });
+                        if let Ok(json) = serde_json::to_vec(&reply) {
+                            let _ = write_message(&mut stream, &json);
+                        }
+                        let _ = stream.shutdown(std::net::Shutdown::Write);
+                        continue;
+                    }
+                };
+
+                let (tx, rx) = mpsc::channel();
+                let _ = cmd_tx.send((cmd, tx));
+
+                if let Ok(reply) = rx.recv() {
+                    if let Ok(json) = serde_json::to_vec(&reply) {
+                        let _ = write_message(&mut stream, &json);
+                    }
+                    let _ = stream.shutdown(std::net::Shutdown::Write);
                 }
             }
             Err(e) => eprintln!("Socket error: {}", e),
@@ -243,17 +264,18 @@ fn socket_listener(cmd_tx: mpsc::Sender<(DaemonCommand, mpsc::Sender<String>)>) 
 fn handle_command(
     state: &Rc<RefCell<DaemonState>>,
     cmd: DaemonCommand,
-    response_tx: mpsc::Sender<String>,
+    response_tx: mpsc::Sender<DaemonReply>,
 ) {
     let mut state_ref = state.borrow_mut();
 
     match cmd {
         DaemonCommand::Open { url, name } => {
-            // Check if name is already in use
             if let Some(ref n) = name
                 && state_ref.tabs.iter().any(|t| t.name.as_deref() == Some(n))
             {
-                let _ = response_tx.send(format!("Tab name '{}' already in use\n", n));
+                let _ = response_tx.send(DaemonReply::Err(DaemonError::NameInUse {
+                    name: n.clone(),
+                }));
                 return;
             }
 
@@ -263,14 +285,14 @@ fn handle_command(
                 format!("https://{}", url)
             };
 
-            // Create a new software rendering context for this tab
             let size = PhysicalSize::new(1024, 768);
             let rendering_context: Rc<dyn RenderingContext> =
                 match SoftwareRenderingContext::new(size) {
                     Ok(ctx) => Rc::new(ctx),
                     Err(e) => {
-                        let _ = response_tx
-                            .send(format!("Failed to create rendering context: {:?}\n", e));
+                        let _ = response_tx.send(DaemonReply::Err(DaemonError::PageError {
+                            message: format!("Failed to create rendering context: {:?}", e),
+                        }));
                         return;
                     }
                 };
@@ -281,12 +303,14 @@ fn handle_command(
             let servo_url = match Url::parse(&full_url) {
                 Ok(u) => u,
                 Err(e) => {
-                    let _ = response_tx.send(format!("Invalid URL: {:?}\n", e));
+                    let _ = response_tx.send(DaemonReply::Err(DaemonError::InvalidUrl {
+                        url: full_url,
+                        reason: format!("{:?}", e),
+                    }));
                     return;
                 }
             };
 
-            // Create WebView
             let delegate = Rc::new(MechWebViewDelegate {
                 state: state.clone(),
             });
@@ -307,21 +331,23 @@ fn handle_command(
             let display_name = name
                 .map(|n| format!("{} ({})", tab_id + 1, n))
                 .unwrap_or_else(|| (tab_id + 1).to_string());
-            let _ = response_tx.send(format!("Opened tab {} at {}\n", display_name, url));
+            let _ = response_tx.send(DaemonReply::ok_message(format!(
+                "Opened tab {} at {}\n",
+                display_name, url
+            )));
         }
 
         DaemonCommand::Show { tab, path, color } => {
             if let Some(idx) = resolve_tab(&state_ref.tabs, &tab) {
                 let tab_data = &state_ref.tabs[idx];
 
-                // Query JavaScript for the current hypermap state
-                // Returns hypermap if available, or diagnostic info if not
+                // Query JavaScript for the current hypermap state.
+                // Returns hypermap if available, or diagnostic info if not.
                 let script = r#"
                     (function() {
                         if (window.hypermap) {
                             return { ok: true, data: JSON.parse(JSON.stringify(window.hypermap)) };
                         }
-                        // No hypermap - gather diagnostic info
                         return {
                             ok: false,
                             readyState: document.readyState,
@@ -333,6 +359,7 @@ fn handle_command(
                 "#
                 .to_string();
 
+                let tab_clone = tab.clone();
                 let path_clone = path.clone();
                 let response_tx_clone = response_tx.clone();
                 tab_data
@@ -341,7 +368,6 @@ fn handle_command(
                         Ok(jsval) => {
                             let response = jsvalue_to_json(&jsval);
 
-                            // Check if we got hypermap data or diagnostic info
                             if response.get("ok") == Some(&Value::Bool(true)) {
                                 let hypermap = response.get("data").cloned().unwrap_or(Value::Null);
 
@@ -352,28 +378,37 @@ fn handle_command(
                                 };
                                 match value {
                                     Some(v) => {
-                                        let _ = response_tx_clone
-                                            .send(format_hypermap_styled(&v, 0, color));
+                                        let _ = response_tx_clone.send(DaemonReply::ok_message(
+                                            format_hypermap_styled(&v, 0, color),
+                                        ));
                                     }
                                     None => {
-                                        let _ =
-                                            response_tx_clone.send("Path not found\n".to_string());
+                                        let _ = response_tx_clone.send(DaemonReply::Err(
+                                            DaemonError::PathNotFound {
+                                                tab: tab_clone.clone(),
+                                                path: path_clone.clone().unwrap_or_default(),
+                                            },
+                                        ));
                                     }
                                 }
                             } else {
-                                // No hypermap - format diagnostic error message
                                 let msg = format_load_error(&response);
-                                let _ = response_tx_clone.send(msg);
+                                let _ = response_tx_clone.send(DaemonReply::Err(
+                                    DaemonError::PageError { message: msg },
+                                ));
                             }
                         }
                         Err(e) => {
-                            let _ = response_tx_clone
-                                .send(format!("Failed to query page: {:?}\n", e));
+                            let _ = response_tx_clone.send(DaemonReply::Err(
+                                DaemonError::PageError {
+                                    message: format!("Failed to query page: {:?}", e),
+                                },
+                            ));
                         }
                     });
-                // Response will be sent by the callback
+                // Response will be sent by the callback above.
             } else {
-                let _ = response_tx.send(format!("Tab '{}' not found\n", tab));
+                let _ = response_tx.send(DaemonReply::Err(DaemonError::TabNotFound { tab }));
             }
         }
 
@@ -381,7 +416,6 @@ fn handle_command(
             if let Some(idx) = resolve_tab(&state_ref.tabs, &tab) {
                 let tab_data = &state_ref.tabs[idx];
 
-                // Just input the value, don't trigger use
                 let script = format!(
                     r#"
                     if (window.hypermap) {{
@@ -391,9 +425,9 @@ fn handle_command(
                     path, value
                 );
                 tab_data.webview.evaluate_javascript(script, |_| {});
-                let _ = response_tx.send(String::new());
+                let _ = response_tx.send(DaemonReply::ok());
             } else {
-                let _ = response_tx.send(format!("Tab '{}' not found\n", tab));
+                let _ = response_tx.send(DaemonReply::Err(DaemonError::TabNotFound { tab }));
             }
         }
 
@@ -401,7 +435,6 @@ fn handle_command(
             if let Some(idx) = resolve_tab(&state_ref.tabs, &tab) {
                 let tab_data = &state_ref.tabs[idx];
 
-                // Set form data first
                 for (key, value) in &data {
                     let full_path = format!("{}/{}", path, key);
                     let script = format!(
@@ -415,7 +448,6 @@ fn handle_command(
                     tab_data.webview.evaluate_javascript(script, |_| {});
                 }
 
-                // Then use the control
                 let script = format!(
                     r#"
                     if (window.hypermap) {{
@@ -426,7 +458,6 @@ fn handle_command(
                 );
                 tab_data.webview.evaluate_javascript(script, |_| {});
 
-                // Update the tab's URL after navigation completes
                 let state_clone = state.clone();
                 tab_data
                     .webview
@@ -440,32 +471,33 @@ fn handle_command(
                         }
                     });
 
-                let _ = response_tx.send(String::new());
+                let _ = response_tx.send(DaemonReply::ok());
             } else {
-                let _ = response_tx.send(format!("Tab '{}' not found\n", tab));
+                let _ = response_tx.send(DaemonReply::Err(DaemonError::TabNotFound { tab }));
             }
         }
 
         DaemonCommand::Fork { tab, name } => {
-            // Check if name is already in use
             if let Some(ref n) = name
                 && state_ref.tabs.iter().any(|t| t.name.as_deref() == Some(n))
             {
-                let _ = response_tx.send(format!("Tab name '{}' already in use\n", n));
+                let _ = response_tx.send(DaemonReply::Err(DaemonError::NameInUse {
+                    name: n.clone(),
+                }));
                 return;
             }
 
             if let Some(idx) = resolve_tab(&state_ref.tabs, &tab) {
                 let source_url = state_ref.tabs[idx].url.clone();
 
-                // Create a new tab with the same URL
                 let size = PhysicalSize::new(1024, 768);
                 let rendering_context: Rc<dyn RenderingContext> =
                     match SoftwareRenderingContext::new(size) {
                         Ok(ctx) => Rc::new(ctx),
                         Err(e) => {
-                            let _ = response_tx
-                                .send(format!("Failed to create rendering context: {:?}\n", e));
+                            let _ = response_tx.send(DaemonReply::Err(DaemonError::PageError {
+                                message: format!("Failed to create rendering context: {:?}", e),
+                            }));
                             return;
                         }
                     };
@@ -476,7 +508,10 @@ fn handle_command(
                 let servo_url = match Url::parse(&source_url) {
                     Ok(u) => u,
                     Err(e) => {
-                        let _ = response_tx.send(format!("Invalid URL: {:?}\n", e));
+                        let _ = response_tx.send(DaemonReply::Err(DaemonError::InvalidUrl {
+                            url: source_url,
+                            reason: format!("{:?}", e),
+                        }));
                         return;
                     }
                 };
@@ -501,42 +536,51 @@ fn handle_command(
                 let display_name = name
                     .map(|n| format!("{} ({})", tab_id + 1, n))
                     .unwrap_or_else(|| (tab_id + 1).to_string());
-                let _ = response_tx.send(format!("Forked to tab {}\n", display_name));
+                let _ = response_tx.send(DaemonReply::ok_message(format!(
+                    "Forked to tab {}\n",
+                    display_name
+                )));
             } else {
-                let _ = response_tx.send(format!("Tab '{}' not found\n", tab));
+                let _ = response_tx.send(DaemonReply::Err(DaemonError::TabNotFound { tab }));
             }
         }
 
         DaemonCommand::Close { tab } => {
             if let Some(idx) = resolve_tab(&state_ref.tabs, &tab) {
                 state_ref.tabs.remove(idx);
-                let _ = response_tx.send(format!("Closed tab '{}'\n", tab));
+                let _ = response_tx.send(DaemonReply::ok_message(format!(
+                    "Closed tab '{}'\n",
+                    tab
+                )));
             } else {
-                let _ = response_tx.send(format!("Tab '{}' not found\n", tab));
+                let _ = response_tx.send(DaemonReply::Err(DaemonError::TabNotFound { tab }));
             }
         }
 
         DaemonCommand::Name { tab, name } => {
-            // Check if new name is already in use
             if state_ref
                 .tabs
                 .iter()
                 .any(|t| t.name.as_deref() == Some(&name))
             {
-                let _ = response_tx.send(format!("Tab name '{}' already in use\n", name));
+                let _ = response_tx.send(DaemonReply::Err(DaemonError::NameInUse { name }));
                 return;
             }
             if let Some(idx) = resolve_tab(&state_ref.tabs, &tab) {
                 state_ref.tabs[idx].name = Some(name.clone());
-                let _ = response_tx.send(format!("Tab {} renamed to '{}'\n", idx + 1, name));
+                let _ = response_tx.send(DaemonReply::ok_message(format!(
+                    "Tab {} renamed to '{}'\n",
+                    idx + 1,
+                    name
+                )));
             } else {
-                let _ = response_tx.send(format!("Tab '{}' not found\n", tab));
+                let _ = response_tx.send(DaemonReply::Err(DaemonError::TabNotFound { tab }));
             }
         }
 
         DaemonCommand::Tabs => {
             if state_ref.tabs.is_empty() {
-                let _ = response_tx.send("No open tabs\n".to_string());
+                let _ = response_tx.send(DaemonReply::ok_message("No open tabs\n"));
             } else {
                 let mut output = String::new();
                 for (i, tab) in state_ref.tabs.iter().enumerate() {
@@ -547,12 +591,12 @@ fn handle_command(
                         .unwrap_or_default();
                     output.push_str(&format!("{}{}  {}\n", i + 1, name_part, tab.url));
                 }
-                let _ = response_tx.send(output);
+                let _ = response_tx.send(DaemonReply::ok_message(output));
             }
         }
 
         DaemonCommand::Shutdown => {
-            let _ = response_tx.send(String::new());
+            let _ = response_tx.send(DaemonReply::ok());
             cleanup();
             process::exit(0);
         }
@@ -588,7 +632,9 @@ fn get_value_at_path<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
     Some(current)
 }
 
-/// Format a diagnostic error message when hypermap content is not available
+/// Build a diagnostic message describing why hypermap content is unavailable.
+/// The returned string is wrapped in `DaemonError::PageError`, so it carries
+/// no trailing newline.
 fn format_load_error(diagnostics: &Value) -> String {
     let ready_state = diagnostics
         .get("readyState")
@@ -607,13 +653,12 @@ fn format_load_error(diagnostics: &Value) -> String {
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    // Check for common error patterns
     let title_lower = title.to_lowercase();
     let body_lower = body_text.to_lowercase();
 
     if title_lower.contains("not found") || body_lower.contains("not found") || title.contains("404")
     {
-        return format!("Page not found (404): {}\n", title);
+        return format!("Page not found (404): {}", title);
     }
 
     if title_lower.contains("error") || body_lower.contains("error") {
@@ -622,25 +667,24 @@ fn format_load_error(diagnostics: &Value) -> String {
         } else {
             body_text.lines().next().unwrap_or("Unknown error")
         };
-        return format!("Page error: {}\n", error_hint);
+        return format!("Page error: {}", error_hint);
     }
 
     if ready_state == "loading" {
-        return "Page is still loading...\n".to_string();
+        return "Page is still loading...".to_string();
     }
 
     if ready_state == "complete" && !has_pre {
-        return "Page loaded but contains no hypermap content (no <pre> element)\n".to_string();
+        return "Page loaded but contains no hypermap content (no <pre> element)".to_string();
     }
 
     if ready_state == "complete" && has_pre {
-        return "Page loaded but hypermap failed to initialize (check if page serves valid JSON)\n"
+        return "Page loaded but hypermap failed to initialize (check if page serves valid JSON)"
             .to_string();
     }
 
-    // Fallback
     format!(
-        "No hypermap content (readyState: {}, title: {})\n",
+        "No hypermap content (readyState: {}, title: {})",
         ready_state,
         if title.is_empty() { "<none>" } else { title }
     )


### PR DESCRIPTION
The daemon protocol uses the varlink wire format end-to-end. JSON messages framed by null bytes over the Unix socket, with shapes that match the `com.hypermap.mech.varlink` interface declarations.

- Commands serialize as `{"method": "Open", "parameters": {...}}`.
- Successful replies as `{"parameters": {"message": "..."}}` (or `{"parameters": {}}` for unit-return methods).
- Errors as `{"error": "TabNotFound", "parameters": {"tab": "1"}}`, with a typed `DaemonError` enum covering `TabNotFound`, `PathNotFound(tab, path)`, `NameInUse`, `InvalidUrl`, and `PageError`. Internal failures (rendering-context creation, JS evaluation) surface as `PageError`.
- `Use.data` is a JSON object (`{"quantity": "5"}`), matching the varlink `[string]string` dictionary type.

The client exits non-zero and writes the rendered error to stderr on any error reply, so shell consumers can branch on exit status.

Build hygiene bundled in:

- Servo and its companion deps (`dpi`, `url`, `libc`, `rustls`) are optional and gated behind a default-on `daemon` feature, with `mechd` declared `required-features = ["daemon"]`. This lets `cargo test --lib --no-default-features` skip Servo's huge build tree entirely while the lib's wire-format tests still exercise the shared types.
- Servo enabled with `default-features = false, features = ["baked-in-resources", "js_jit"]` — drops the unused `clipboard` feature and documents that this is a headless daemon.

36/36 lib roundtrip + wire-shape tests pass under
`cargo test --lib --no-default-features`. `tests/e2e_basic.sh` exercises the full daemon command surface end-to-end against a real hypermap page.